### PR TITLE
Fixes for Window load events in iFrame

### DIFF
--- a/lib/ripple/bootstrap.js
+++ b/lib/ripple/bootstrap.js
@@ -41,34 +41,7 @@ function _createFrame(src) {
                 } else {
                     _bindObjects(frame);
                 }
-            }, 1),
-            ael = frame.contentWindow.addEventListener,
-            handlers = {
-                load: [],
-                DOMContentLoaded: []
-            };
-
-        //HACK: This is to get around a bug in webkit where it doesn't seem to
-        //      fire the load handlers when we readd the iframe back into the DOM
-        //      https://github.com/blackberry/Ripple-UI/issues/190
-        frame.contentWindow.addEventListener = function (event, handler) {
-            if (handlers[event]) {
-                handlers[event].push(handler);
-            }
-            else {
-                ael.apply(this, arguments);
-            }
-        };
-
-        frame.fireHandlers = function (event) {
-            handlers[event].forEach(function (handler) {
-                try {
-                    return handler && handler({});
-                } catch (e) {
-                    _console.error(e);
-                }
-            });
-        };
+            }, 1);
     });
 
     return frame;
@@ -99,8 +72,6 @@ function _post(src) {
             document.querySelector("#ui").removeChild(bootLoader);
         }
 
-        frame.fireHandlers("DOMContentLoaded");
-        frame.fireHandlers("load");
         event.trigger("TinyHipposLoaded");
 
         _cleanBody();

--- a/lib/ripple/deviceMotionEmulator.js
+++ b/lib/ripple/deviceMotionEmulator.js
@@ -42,6 +42,7 @@ function _bind(name, win) {
         }
     };
 }
+
 _self = {
     init: function (frame) {
         var widgetWindow = frame.contentWindow,
@@ -65,14 +66,14 @@ _self = {
                 _motion.set(callback);
             }
             else {
-                add(event, callback);
+                add.apply(widgetWindow, arguments);
             }
         };
 
         widgetWindow.removeEventListener = function (event, callback) {
             _motion.unbind(callback);
             _orientation.unbind(callback);
-            remove(callback);
+            remove.apply(widgetWindow, arguments);
         };
 
         event.on("DeviceMotionEvent", function (motion) {

--- a/test/unit/deviceMotionEmulator.js
+++ b/test/unit/deviceMotionEmulator.js
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2011 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+describe("deviceMotionEmulator", function () {
+    var event = require('ripple/event'),
+        deviceMotionEmulator = require('ripple/deviceMotionEmulator');
+
+    beforeEach(function () {
+        spyOn(event, "on");
+    });
+
+    afterEach(function () {
+    });
+
+    describe("when initializing", function () {
+        it("properly masks frame.addEventListener", function () {
+            var addEventListener = jasmine.createSpy(),
+                callback = jasmine.createSpy(),
+                frame = {
+                    contentWindow: {
+                        addEventListener: addEventListener
+                    }
+                };
+
+            deviceMotionEmulator.init(frame);
+            frame.contentWindow.addEventListener('load', callback, false);
+
+            expect(addEventListener).toHaveBeenCalledWith('load', callback, false);
+        });
+
+        it("properly masks frame.removeEventListener", function () {
+            var removeEventListener = jasmine.createSpy(),
+                callback = jasmine.createSpy(),
+                frame = {
+                    contentWindow: {
+                        removeEventListener: removeEventListener
+                    }
+                };
+
+            deviceMotionEmulator.init(frame);
+            frame.contentWindow.removeEventListener('load', callback, false);
+
+            expect(removeEventListener).toHaveBeenCalledWith('load', callback, false);
+        });
+    });
+});


### PR DESCRIPTION
Fixes:

[ripple/boostrap] does not pass event object to listeners on window load/DOMContentLoaded - [#217](https://github.com/blackberry/Ripple-UI/issues/217)

[lib/deviceMotionEmulator] does not pass all arguments to window.addEventListener/removeEventListener - [#216](https://github.com/blackberry/Ripple-UI/issues/216)

(removed Hotfix) window load event handlers are not triggered when navigating inside app - [#190](https://github.com/blackberry/Ripple-UI/issues/190)
