### PR TITLE
Bugfixes for blackberry.io namespace

### DIFF
--- a/lib/ripple/platform/webworks.core/2.0.0/client/utils.js
+++ b/lib/ripple/platform/webworks.core/2.0.0/client/utils.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var _hate = {};
+var _blobs = {};
 
 function _blobBuilder() {
     var BlobBuilder = BlobBuilder || WebKitBlobBuilder;
@@ -105,19 +105,20 @@ module.exports = {
     },
 
     blobToString: function (blob, encoding) {
-        return _hate[blob.uuid];
+        return _blobs[blob.id];
     },
 
     stringToBlob: function (string, encoding) {
-        var uuid = Math.uuid(undefined, 16),
+        var id = Math.uuid(undefined, 16),
             blob = _blobBuilder(),
             finalBlob;
 
-        _hate[uuid] = string;
+        _blobs[id] = string;
         blob.append(string);
 
         finalBlob = blob.getBlob();
-        finalBlob.uuid = uuid;
+        finalBlob.id = id;
+        finalBlob.length = finalBlob.size;
 
         return finalBlob;
     }

--- a/lib/ripple/platform/webworks.core/2.0.0/fsCache.js
+++ b/lib/ripple/platform/webworks.core/2.0.0/fsCache.js
@@ -52,7 +52,7 @@ event.on("FileSystemInitialized", function () {
     _createPath("/accounts/1000/appdata/emulatedapp/shared/downloads");
     _createPath("/accounts/1000/appdata/emulatedapp/shared/misc");
     _createPath("/accounts/1000/appdata/emulatedapp/shared/music");
-    _createPath("/accounts/1000/appdata/emulatedapp/shared/photo");
+    _createPath("/accounts/1000/appdata/emulatedapp/shared/photos");
     _createPath("/accounts/1000/appdata/emulatedapp/shared/print");
     _createPath("/accounts/1000/appdata/emulatedapp/shared/videos");
     _createPath("/accounts/1000/appdata/emulatedapp/shared/voice");
@@ -147,7 +147,6 @@ _self = {
     file: {
         exists: function (path) {
             var entry = _get(path);
-            fs.stat(path, function () {}, _fsError);
             return !!(entry && !entry.isDirectory);
         },
 
@@ -269,7 +268,6 @@ _self = {
 
         exists: function (path) {
             var entry = _get(path);
-            fs.stat(path, function () {}, _fsError);
             return !!(entry && entry.isDirectory);
         },
 
@@ -293,10 +291,6 @@ _self = {
 
             var entry = _get(path),
                 array = path.split("/");
-
-            fs.stat(path, function (entry) {
-                entry.getParent(function (p) {}, _fsError);
-            }, _fsError);
 
             return entry ? array.splice(0, array.length - 1).join("/") || "/" : null;
         },

--- a/test/unit/webworks/fsCache.js
+++ b/test/unit/webworks/fsCache.js
@@ -76,17 +76,11 @@ describe("fsCache", function () {
             it("returns true when the file exists", function () {
                 spyOn(fs, "stat");
                 expect(cache.file.exists("/hungry.js")).toBe(true);
-                expect(fs.stat.argsForCall[0][0]).toBe("/hungry.js");
-                expect(typeof fs.stat.argsForCall[0][1]).toBe("function");
-                expect(typeof fs.stat.argsForCall[0][2]).toBe("function");
             });
 
             it("returns false when when given a directory", function () {
                 spyOn(fs, "stat");
                 expect(cache.file.exists("/dudeDir")).toBe(false);
-                expect(fs.stat.argsForCall[0][0]).toBe("/dudeDir");
-                expect(typeof fs.stat.argsForCall[0][1]).toBe("function");
-                expect(typeof fs.stat.argsForCall[0][2]).toBe("function");
             });
         });
 
@@ -177,36 +171,22 @@ describe("fsCache", function () {
             it("returns true when the directory exists", function () {
                 spyOn(fs, "stat");
                 expect(cache.dir.exists("/dudeDir")).toBe(true);
-                expect(fs.stat.argsForCall[0][0]).toBe("/dudeDir");
-                expect(typeof fs.stat.argsForCall[0][1]).toBe("function");
-                expect(typeof fs.stat.argsForCall[0][2]).toBe("function");
             });
 
             it("returns false when given a file", function () {
                 spyOn(fs, "stat");
                 expect(cache.dir.exists("/hungry.js")).toBe(false);
-                expect(fs.stat.argsForCall[0][0]).toBe("/hungry.js");
-                expect(typeof fs.stat.argsForCall[0][1]).toBe("function");
-                expect(typeof fs.stat.argsForCall[0][2]).toBe("function");
+            });
+
+            it("returns true when the directory exists", function () {
+                spyOn(fs, "stat");
+                expect(cache.dir.exists("/dudeDir")).toBe(true);
             });
         });
 
         describe("getParentDirectory", function () {
             it("returns the path to the parent directory", function () {
-                var entry = {
-                    getParent: jasmine.createSpy()
-                };
-
-                spyOn(fs, "stat").andCallFake(function (path, success, error) {
-                    success(entry);
-                });
-
                 expect(cache.dir.getParentDirectory("/dudeDir")).toBe("/");
-                expect(fs.stat.argsForCall[0][0]).toBe("/dudeDir");
-                expect(typeof fs.stat.argsForCall[0][1]).toBe("function");
-                expect(typeof fs.stat.argsForCall[0][2]).toBe("function");
-                expect(typeof entry.getParent.argsForCall[0][0]).toBe("function");
-                expect(typeof entry.getParent.argsForCall[0][1]).toBe("function");
             });
         });
 

--- a/test/unit/webworks/utils.js
+++ b/test/unit/webworks/utils.js
@@ -53,7 +53,7 @@ describe("utils", function () {
         it("can translate a blob into a string and back", function () {
             var blobBuilder = {
                     append: jasmine.createSpy(),
-                    getBlob: jasmine.createSpy().andReturn({})
+                    getBlob: jasmine.createSpy().andReturn({size: 3})
                 },
                 str = "da foo",
                 blob;
@@ -62,7 +62,8 @@ describe("utils", function () {
 
             blob = utils.stringToBlob(str);
 
-            expect(blob.uuid).toBeDefined();
+            expect(blob.id).toBeDefined();
+            expect(blob.length).toBeDefined();
             expect(utils.blobToString(blob)).toEqual(str);
             expect(utils.stringToBlob(str)).toEqual(blob);
             expect(blobBuilder.append).toHaveBeenCalledWith(str);


### PR DESCRIPTION
Fixes for:
#227 - [BB device] blackberry.io.dir.exists generates exceptions
#228 - [BB device] blackberry.io.dir.getParentDirectory generates exception
#229 - [BB device ] blackberry.io.file.readFile set wrong property in callback function
#230 - [PB] all subfolders under shared folder do not exist
#235 - [BB device] blackberry.io generates exceptions when specify "/" at the end of path
