### PR TITLE
Ported Changelog From rippledocs to doc/CHANGELOG.md

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,0 +1,561 @@
+## v0.9.1 - November 11, 2011
+
+* Added remote web inspector option for WebWorks and WebWorks TabletOS platforms, which is disabled by default.
+* Listen for AppCache updateready events and reload accordingly.
+* Bootstrap addEventListener hijacker dies if registered callback throws exception.
+* Added a module (dbfs) to remove dependency on File API for blackberry.io.{dir|file} (for the time being).
+* Added blackberry.io.dir.appDirs property for tablet and improved filesystem initialization to include directories expected for both tablet and handset.
+* (Hotfix) window load event handlers are not triggered when navigating inside app container (i.e. inside iframe). See [Issue #190](https://github.com/blackberry/Ripple-UI/issues/190).
+
+## v0.9.0 - October 18, 2011
+
+* Added Omnibar plugin to web build
+* Removed vodaphone, opera, wac platforms
+* Added agnostic filesystem api (thin wrapper for W3C File API)
+* Added support for blackberry.io.file and blackberry.io.dir (including blackberry.utils.stringToBlog and blobtoString)
+* Added APIs for blackberry.app.event.onSwipeDown and blackberry.app.event.onSwipeStart for WebWorks Tablet
+* Added support for manually firing events in the PhoneGap Events API
+* Added various BB device skins
+* Add controls for BB build and deploy service
+* Support clientX property in touch events
+* Added cache.manifest support to web build
+* (Fix) [WebWorks] bb.invoke.invoke launches undefined application for CameraArguments
+* (Fix) [WebWorks] sms.isListeningForMessage should be settable
+* (Fix) [WebWorks] bb.app issues
+* (Fix) [WebWokrs] bb.ui.menu issues
+* (Fix) [PhoneGap] When successfully removing a contact, a list of contacts is incorrectly returned
+* (Fix) [PhoneGap] When saving a contact, the returned list is incorrect
+* (Fix) [WebWorks-TabletOS] bb.invoke Browser: URLs do not support certain protocols
+* (Fix) [WebWorks-TabletOS] bb.system.hasPermission() generates exception
+* (Fix) [WebWorks-TabletOS] - blackberry.ui.dialog.standard/customAskAsync settings parameter does not work
+* (Fix) [WebWorks-TabletOS] - blackberry.ui.dialog missing some constant definitions
+* (Fix) [WebWorks/WebWorks-TabletOS] Duplicate versions in platform version select dropdown
+* (Fix) WebWorks-TabletOS platform initializes UI plugins that are specific to WebWorks
+* (Fix) The Back Button on a Device Skin only works on WebWorks platforms
+* (Fix) [WebWorks] blackberry.invoke.invoke generates exceptions
+* (Fix) [WebWorks] blackberry.identity issues
+* (Fix) [WebWorks] wrong attributes validation in config.xml for rim:transitionEffect
+* (Fix) [PhoneGap] contacts.find can not return all contact fields when given "*" for fields param
+* (Fix) [WebWorks] rim:navigation property is not displayed in the config panel
+* (Fix) gamma value in accelerometer UI panel posts no useful information
+* (Fix) [WebWorks] PhoneLogs.addPhoneLogListener does not return a Boolean
+* (Fix) [WebWorks] When a call log record is added, onCallLogAdded is called with an empty object
+* (Fix) [WebWorks] bb.audio does not keep consistence with the supported formats on a device
+* (Fix) [WebWorks-TabletOS] invoke.APP_UPDATE should NOT exist on PlayBook
+* (Fix) [WebWorks-TabletOS] system.setHomeScreenBackground should not exist
+* (Fix) In the accelerometer panel, after rotating the device, then shaking the xAxis automatically resets back to 0
+* (Fix) iFrame shows scroll bars when content overflows
+* (Fix) SMS and Data text boxes too big
+* (Fix) Can't switch to Nokia N97 (Touch) Device
+* (Fix) Fixed fetching of config.xml relative to application content (on web build)
+
+## v0.6.3 - October 7, 2011
+
+* HOTFIX - Fixed load event not firing on navigation as well as bug with jQuery Mobile
+
+## v0.6.1 - August 23, 2011
+
+* jake build now places compiled folders in pkg/ (vs ../ripple_build)
+* Tweaked bootstrap module to ensure APIs are properly injected when navigating within the iFrame
+* Updated PhoneGap (visually) to 1.0
+* Updated PhoneGap Contacts namespace (to navigator.contacts)
+* Updated PhoneGap Connection API (and deprecated old network API)
+* Fixed W3C Geolocation data values initially being 0
+* Created a WebWorks-TabletOS platform, and split original WebWorks into webworks.tablet, webworks.handset and webworks.core
+* Phone.addPhoneListener called with eventType of 0 (CB_CALL_INITIATED) did not assign the event (webworks.handset)
+* Phone.addPhoneListener returns true when successfully assigned (webworks.handset)
+* CallLog is exposed publicly (webworks.handset)
+* Added WebWorks show and remove Banner APIs to webworks.handset
+* Implemented SystemEvent APIs for webworks.tablet (i.e. Playbook)
+* Fixed onHardwareKey and onCoverageChange events in SystemEvent API for webworks.handset
+* Added the DeviceOrientation W3C APIs (to all platforms)
+* Fixed webworks.core select module to handle -1 and null .max() values
+* Added Invoke API to WebWorks-TabletOS
+* Added .jshintignore file (and added node-jshint --show-non-error option to jake lint)
+
+## v0.6.0 - August 02, 2011
+
+* Fixed WebWorks pim.category to be in correct place (pim.category.XXX vs pim.XXX)
+* Added missing accuracy property to PhoneGap (i.e. W3C) geolocation
+* Removed vendor specific branding from Torch skin
+* Fixed not being able to save any new Contacts in WebWorks
+* Fixed Find in WebWorks
+* Fixed a UI bug causing boolean based device settings to always return true
+* Added W3C geolocation implementation to mobile web platform
+* Added W3C geolocation implementation to WebWorks platform
+* Fixed bug where you could not disable Ripple when auto-enabled
+
+## v0.5.4 - June 27, 2011
+
+* Added Bold 9900 to devices
+* Added ability to bypass and better simulate CORS requests with the --disable-web-security flag (more info coming soon) 
+* Fixed issues with running webworks on the file scheme
+* Fixed generation of uids on blackberry.message.Message
+* Fixed return value of blackberry.message.sms.removeReceiveListener
+* Fixed blackberry.identity.phone.getLineIds
+* Updated our error page to get rid of references to setting the delay (but not the zombies)
+* updated our bootstrap/injection code to be closured better
+
+## v0.5.3 - June 20, 2011
+
+* Added Nexus S to devices
+* Missing Storage UI panel in WAC
+* Added additional apps to launch via invoke (Search, Memo, Java, Calendar, AddressBook)
+* blackberry.app.id returns undefined
+* blackberry.menu cannot set property 'isDefault' of undefined
+* blackberry.app.setHomeScreenIcon doesn't return a bool
+* blackberry.app.setHomeScreenName doesn't return a bool
+* blackberry.invoke breakage (TaskArguments, PhoneArguments, MessageArguments)
+
+## v0.5.2 - May 26, 2011
+
+* Fixed (missed) breakages in a number of WebWorks apis
+
+## v0.5.1 - May 24, 2011
+
+ * Updated the device orientation UI to better support devices that don't support it.
+ * Updated UI plugins so code is not executed if the plugin isn't available 
+ * Updated Ripple to use UglifyJS to compress code 
+ * Added a device default orientation (e.g. Playbook defaults to Landscape) 
+ * Fixed Selected Platform showing as Mobile Web Vdefault type-o
+ * Fixed Playbook image sprite
+ * Fixed Playbook skin, landscape/portrait mismatch 
+ * Fixed UI for handling of Webworks default menu item to be more clear as to which is the default item
+ * Fixed Ripple :: Initialization Finished (Make it so.) being logged twice
+ * Fixed bug where on first run the platform selection buttons were not clickable
+
+## v0.5.0 - May 11, 2011
+
+* Added support for the Webworks Platform
+* Only Webworks APIs listed in the config.xml are available for the app (all are available if there is no config)
+* Removed visual scrollbars for applications that scroll on body
+* Added Device skinning support and added BlackBerry Skins (Torch, Bold, Playbook)
+* Added functional back and menu buttons for (applicable) Blackberry devices (on WebWorks).
+* Implement getAllResponseHeaders on jsonp XHR
+* Mixin platform api methods into their respective objects if they already exist in window, instead of overwriting it (ex. window.navigator on PhoneGap)
+* Use latest jWorkflow (0.4.0)
+* Use latest jQuery (1.6) and jQuery UI (1.8.12)
+* Renamed Webworks version from 1.0.0 to 2.0.0
+* Refactor to use the CommonJS module pattern
+* Added iPad to PhoneGap
+* Fixed XHR to not do CORS if on the same domain
+* Fixed handling of errors and when to show the error page
+* Fixed selected platform showing as Mobile Web Vdefault
+* Fixed Invalid data being put into Geolocation UI
+* Fixed xml config parsing should parse features into appInfo
+* Fixed unreadable (light) background on selected boxes in Chrome ~12
+* Removed PPI Emulation
+* Fixed Playbook user agent string
+* Fixed scrollbars rendering incorrectly on Windows XP
+* When ripple is updated it uses the HTML5 notifications API instead of popping up an annoying window
+
+## v0.4.14 - April 21, 2011 (HOT FIX)
+
+* HOTFIX: Fix bug where loading a Sencha Touch 1.1.0 application caused the emulation window to shift to the left.
+* HOTFIX: Fix bug where XMLHttpRequest.getAllResponseHeaders() was throwing an "unimplemented" exception for jsonp calls.
+
+## v0.4.13 - April 14, 2011 (HOT FIX)
+
+* HOTFIX: Fix bug where loading a Sencha Touch 1.1.0 application caused the emulation window to shift to the left.
+* Update the Ripple product Update page
+
+## v0.4.12 - March 16, 2011 (HOT FIX)
+
+* HOTFIX: Ensured that XHR proxy is not called for non-Cross Origin requests.
+
+## v0.4.11 - March 05, 2011 (HOT FIX)
+
+* Implemented workaround for NS Basic/App Studio that was causing Ripple to crash
+
+## v0.4.10 - Feb 24, 2011 (HOT FIX)
+
+* Fixed first run window bug, selected is now remembered when Ripple loads
+* Fixed proxy redirection bug for XMLHTTPRequest, local URLs were being identified as external URLs
+* Removed view port sizing for iPhone 3g for the PhoneGap platform
+
+## v0.4.9 - Feb 16, 2011
+
+* Split platform selection and device selection into two separate panels
+* Fixed Accelerometer bug ( Gravity FAIL :-) )
+
+## v0.4.8 - Feb 07, 2011
+
+* Added support for:
+    * PhoneGap Compass
+    * PhoneGap.available property
+    * Ability to auto-enable Ripple with "enableripple=true" querystring parameter
+
+* Fixed Accelerometer bug ( Trigonometry FAIL :-) )
+* Removed Storage UI panel for PhoneGap
+
+## v0.4.7 - Jan 28, 2011
+
+* Fixed Messaging.sendMessage validation bug (WAC)
+
+## v0.4.6 - Jan 26, 2011
+
+* Updated notification pane to position over the emulated mobile device
+* Added support for the PhoneGap contacts API
+* Fixed Audio and Video bugs
+* Added UI element in Ripple to deal with Video Player
+
+## v0.4.5 - Jan 14, 2011
+
+* removed tinyhippos prefix from css rules
+* added some more parameter validation to the WAC runtime in PIM, VideoPlayer, AudioPlayer, Camera
+* Added PhoneGap config validation
+* We now display the widget name, version and icon in the infopane on Phonegap based on the config.xml
+* Added the ability to simulate a GPS timeout on WAC and Phonegap
+* Disable ability to enable ripple on a directory listing in the file:/// scheme (security issues)
+* Prevent ripple from injecting itself on non html files (img, js, css, etc)
+* Support for touchstart, touchmove and touchend DOM events.
+
+## v0.4.3 - Dec 22, 2010
+
+* Improved bootup sequence (ripple would present a white screen on bootup)
+* Added support for network.isReachable (PhoneGap)
+* Fixed a bug with Widget.Messaging.createMessage (WAC)
+* Fixed several minor bugs in Widget.PIM (WAC)
+* Instantiable objects in WAC now work as expected with the "instanceof" operator
+* Fixed bug in Widget.Multimedia.Camera.setWindow not working
+
+## v0.4.2 - Dec 16, 2010
+
+* can run without the need of a local webserver
+    * Please run Chrome with the --allow-file-access-from-files command line option for this to work
+    * You need to ensure that the "Allow Access to file URLS" option on the extension page for Ripple
+
+* QuirksMode support for JIL 1.0/1.2 setPreferenceForKey is deprecated.
+* Update Information pane and device information
+* Add in a hardcoded set of Contacts (currently only available after the body.onload)
+* Fix Message class to be constructable
+* DeviceStateInfo.onScreenChangeDimensions should not be supported
+* Add jQuery AOP reference to main license
+* Fixed boolean device settings would always be enabled
+* Widget.Multimedia.AudioPlayer issue: media file not played after play function call.
+* Widget.Multimedia.AudioPlayer open method is now sync
+* Fixes to get Ripple working in Chrome 8/9/10
+* Widget.Messaging.createMessage doesn't return a message object
+* Support instanceof on instance types in WAC
+
+## v0.4.1 - Dec 6, 2010
+
+* Support for new devices in on the mobile web platform:
+    * Blackberry Playbook
+    * Blackberry Torch
+    * Blackberry Bold 97xx
+    * Nokia N8
+
+* Support for new devices on the phonegap platform
+    * Blackberry Torch
+    * Blackberry Bold 97xx
+    * Nokia N8
+    * Palm Pre 2
+
+* Improved injection issues on some sites
+* Fixed error where sites that did fast dom manipulation would corrupt ripple's UI
+* First run window will no longer refresh multiple times
+* Made ripple loading sequence look nicer
+* Added support for geolocation delay to phonegap and vodafone
+* Moved geolocation delay to the geo panel rather than in device settings
+* Tooltip settings will now persist
+* Ripple no longer needs to refresh when navigating links inside the application
+* Fixed some issues with the back button looping when navigating inside the emulated application
+* Fixed a bug where device settings default values would stay true even when unchecked
+* Ripple can now be disabled from lower level directories when enabled from a top level directory
+* fixed emulation of window.screen size properties in screen and window
+* Improvements to the Device Information UI
+
+## v0.4.0 - Nov 30, 2010
+
+* Read our blog post about this release - http://tinyhippos.com/2010/11/30/ripple-0-4-0-released/">here</a>
+* New emulation code
+    * Support for Sencha Applications
+    * Support for jqTouch
+    * Improved support for jQuery Mobile
+    * Faster bootup times
+    * API Objects are now available for use at eval time
+
+* Improved Accelerometer control
+* Added Camera Support to Vodafone
+* Renamed JIL to WAC
+* Renamed Vodafone 360 to Vodafone
+* Changed Phonegap version from 0.9.1 to 0.9
+* Snapping of phone to the side of the browser when hiding the panels
+* Support for emulation of new devices on the mobile web platform:
+    * iPhone 4
+    * Playbook
+    * Nokia N8
+
+* Bug Fixes:
+    * Fixed race condition when enabling ripple.
+    * Fixed cases where dynamically inserted css links were not handled by the emulator.
+    * Style attribute on body tag is no longer removed.
+    * Fixed handling of position fixed
+    * Added a default background (white) for cases where the users markup doesn't have a background colour
+    * Fixed bug where earlier versions of prototype would cause ripple to not load
+
+## v0.3.8 - Nov 19, 2010
+
+* Fixed bug where jQuery mobile alpha 2 wouldn't render
+
+## v0.3.7 - Nov 15, 2010
+
+* JIL: Widget.Multimedia.VideoPlayer support
+* JIL: Widget.Messaging improved support
+* JIL: Widget.Multimedia.Camera support
+* Styling on html tag now fully emulated
+* /virtual/widgethome now automatically mapped to the widgets url
+* Fixed long standing issue with XHR CORs
+
+## v0.3.6 - Oct 26, 2010
+
+* Fixed Geolocation callback failure in DeviceStateInfo (JIL).
+
+## v0.3.5 - Oct 22, 2010
+
+* Improved JIL support
+    * Messaging.createMessage
+    * Messaging.sendMessage (partial)
+    * PIM.CalendarItem
+    * PIM.addCalendarItem
+    * PIM.deleteCalendarItem
+    * PIM.getCalendarItem
+    * PIM.getCalendarItems
+    * PIM.findCalendarItems
+    * PIM.onCalendarItemsFound
+* JIL/Vodafone now have Device Option for delay for onPositionRetrieved
+* window.onload and body onload now handled properly
+* window.onresize now fires properly
+* window.innerHeight/Width now emulated properly
+* Styling on body tag now fully emulated
+* Added a PhoneGap demo widget. See it http://rippledemo.tinyhippos.com/phonegap/index.html
+* Discovered issues in Ripple with prototype.js version 1.6.1 and earlier.
+* Discovered bug: using fixed positioning in css may not result in desired layout in Ripple
+
+## v0.3.4 - Oct 15, 2010
+
+* Improved JIL support:
+    * PIM.AddressBookItem
+    * PIM.createAddressBookItem
+    * PIM.findAddressBookItems
+    * PIM.getAddressBookItem
+    * PIM.getAddressBookItemsCount
+    * PIM.onAddressBookItemsFound
+    * PIM.addAddressBookItem
+    * PIM.deleteAddressBookItem
+* OMGWTFBBQ
+* Mapping to Body tag now fully supported
+* Fixed Language device setting select for UI for Vodafone 360
+
+## v0.3.1 to v0.3.3 - Oct 7, 2010 - Bug fixes
+
+* Ripple failing with 100% CPU usage on Mac OS X
+* Ripple showing scrollbars on body
+* Phonegap deviceready event should fire from document rather then window
+
+## v0.3.0 - Oct 3, 2010
+
+* Added support for PhoneGap
+* Vodafone 360 separated from JIL into its own platform
+* Additional JIL support for specific API support)
+    * DeviceInfo.phoneOS
+    * DeviceInfo.phoneModel
+    * DeviceInfo.phoneManufacturer
+    * DeviceInfo.phoneFirmware
+    * DeviceInfo.phoneSoftware
+    * DeviceStateInfo.language
+    * Telephony.findCallRecords
+    * Telephony.getCallRecord
+    * Telephony.getCallRecordCnt
+    * Telephony.initiateVoiceCall
+    * Telephony.onCallRecordsFound
+    * Telephony.onCallEvent
+
+* Panel arrangements are now saved per platform instead of globally
+* Implemented viewport sizing for various platforms and their devices
+* Switched main persistence to SQLite
+* Added platform select window when initially enabled for a specific URL
+* Modified Platforms panel
+    * Platform select is now platform only. Version select is now separate
+    * Must now click "Change Platform" to trigger the change
+* Accelerometer now has Shake feature (all platforms)
+* Panel panes are collapsible
+* Removed "Update" button from all panels (information is saved automatically)
+* body id/class attributes get emulated properly
+
+## V0.2.4 - August 17th, 2010
+
+* Updated PPI emulation: all assets get sized correctly
+* Added a generic phone wrapper to the emulated widget
+* Optimized Ripple's loading time and package size for better performance
+* Updated the UI panels to only display if they are relevant to the current platform being used
+* Opera - fires "resolution" event when screen resolution/orientation changes
+* JIL - Added support for:
+    * DataNetworkConnectionTypes
+    * DataNetworkInfo.isDataNetworkConnected
+    * DataNetworkInfo.onNetworkConnectionChanged
+    * DataNetworkInfo.getNetworkConnectionName
+    * DataNetworkInfo.networkConnectionType
+    * RadioInfo.isRadioEnabled
+    * RadioInfo.isRoaming
+    * RadioInfo.radioSignalSource
+    * RadioInfo.radioSignalStrengthPercent
+    * RadioInfo.onSignalSourceChange
+    * PowerInfo.onLowBattery
+    * PowerInfo.onChargeLevelChange
+    * PowerInfo.onChargeStateChange
+    * PowerInfo.isCharging
+    * PowerInfo.percentRemaining
+    * Config.setAsWallpaper
+    * Config.setDefaultRingtone
+    * Config.ringtoneVolume
+    * Config.msgRingtoneVolume
+    * Config.vibrationSetting
+* BUG FIX: Changing platform will now refresh Ripple with the correct platform (no longer need to change the device to trigger the change)
+
+## V0.2.2 to V0.2.3 - July 27th, 2010 - Bug Fixes
+
+* Fixed table color not properly inheriting CSS defined color
+* Opera bug Fixed a typo in configuration validation
+* Fixed Background color not being set properly in the widget container
+* JIL bug fixes (AccountInfo.userAccountBalance and DeviceInfo.phoneColorDepthDefault -> was a string not a numerical value)
+
+## V0.2.1 - July 21th, 2010
+
+* Small UI updates, including cleanup and some minor rearranging of the Platform panel
+* Fixed 2 JIL platform bugs
+    * DeviceInfo.totalMemory was a string updated to a number
+    * DeviceStateInfo.availableMemory was a string updated to a number
+
+
+## V0.2.0 - July 19th, 2010
+
+* Added support for the following JIL APIs
+    * Multimedia.getVolume
+    * Multimedia.stopAll
+    * Multimedia.isAudioPlaying
+    * AudioPlayer.open
+    * AudioPlayer.play
+    * AudioPlayer.pause
+    * AudioPlayer.resume
+    * AudioPlayer.stop
+    * AudioPlayer.onStateChange
+    * Device.widgetEngineName
+    * Device.widgetEngineProvider
+    * Device.widgetEngineVersion
+    * Device.vibrate
+    * RadioInfo.isRadioEnabled
+    * RadioInfo.isRoaming
+    * DataNetworkInfo.isDataNetworkConnected
+    * DeviceStateInfo.keypadLightOn
+    * DeviceStateInfo.backLightOn
+    * DeviceStateInfo.availableMemory
+    * DeviceStateInfo.audioPath
+    * DeviceStateInfo.processorUtilizationPercent
+    * DeviceInfo.totalMemory
+    * DeviceInfo.phoneColorDepthDefault
+    * AccountInfo.phoneUserUniqueId
+    * AccountInfo.phoneMSISDN
+    * AccountInfo.phoneOperatorName
+    * AccountInfo.userAccountBalance
+    * AccountInfo.userSubscriptionType
+    * Account.phoneName
+    * Account.phoneId
+
+* Update UI for themes to allow for better readability
+* Implemented basic virtual file system
+* Various paper-cuts and small bug fixes
+
+## V0.1.186 - June 24th, 2010
+
+* You can now do full cross domain XMLHttpRequests using both GET and POST methods as well as chose whether you want to make those requests synchronously or asynchronously
+* We have added themes to Ripple... I won't tell you where they are, you'll have to go exploring a little.
+* Updated the move and collapse controls for our panels. They should be more intuitive now
+* Move our change log to our documentation site
+* Updated the documentation site
+* Updated the Welcome/Version update popup screen
+
+## V0.1.158 - June 7th, 2010
+
+* Bug fix: Persistence race condition, causing preferences to not save properly when widget first loaded.
+* Added update and welcome popup notifications to inform user of automatic updates.
+* Updated the Ripple logo.
+
+## V0.1.137 - May 26th, 2010
+
+* JIL 1.2.1 :: Added simple support for Widget.Device.DeviceStateInfo.AccelerometerInfo.
+* JIL 1.2.1 :: Added support for config defined preferences.
+* JIL 1.2.1 :: Added support for <strong>read-only</strong> config defined preferences.
+* Preferences are now widget specific. Preferences saved in one widget will not show up in another.
+* Minor CSS fixes for Notifications.
+
+## V0.1.97 - May 17th, 2010
+
+* Updated the way widget gets encapsulated and CSS styles applied. Should fix some widget display bugs.
+* Fixed problem with JSON to ensure that internal version did not get overridden, but loaded widget.
+* Fixed OpenURL for both JIL and Opera.
+* Other small bug fixes.
+
+## V0.1.6 - V0.1.44
+
+* Fixed close button on error notifications to actually work.
+* Added support for widget DOM injected content (for document.body), to ensure that the content gets inserted into the widget container as opposed to into the Body node.
+* Added support for widget screen sizing based on available pixels (i.e. view port size) as opposed to device screen size.
+* Added new devices to JIL 1.2.1 framework based on the list provided by Vodafone.
+* Added warning if config.xml does not exist for a widget the requires it.
+* Added warning if widget version does not match that of selected platform.
+* Added support for screen.height, screen.availHeight (both the have the same value for now).
+* Added support for screen.width, screen.availWidth  (both the have the same value for now).
+* Will remember the state of the tool tips (on or off)
+* Fixed zoom level on GPS map
+
+## V0.1.6
+
+* Added support for Widget.Device.DeviceStateInfo.onScreenChangeDimensions and Widget.onMaximize callback functions being
+    called when device orientation is changed (i.e. going from Landscape to Portrait).
+* Fixed a typo in link to demo widget 
+* Added the What's New panel
+
+## V0.1.3
+
+* Updated PPI emulation to be optional, user must now select this feature.
+* Updated Persistence "clear all" to not remove Ripple application state info. (bug fix) 
+
+## V0.1.2
+
+* Added Options page with information on each release as well as providing helpful information.
+* Added link in the Ripple popup page to the Demo widget providing a step by step walk through the features available in Ripple
+
+## V0.1.1
+
+* Completed JIL API implementation. All unsupported methods will raise appropriate Exceptions. 
+
+## V0.1.0
+
+* Supports general web app development.
+* Supports Opera and JIL (subset of API) mobile widget platforms.
+* Widget.onWakeup
+* Widget.onMaximize
+* Widget.onFocus
+* Widget.onRestore
+* Widget.setPreferenceForKey
+* Widget.preferenceForKey
+* Widget.openUrl
+* Widget.ExceptionTypes
+* Widget.Exception
+* Widget.Device.widgetEngineName =&gt; Static non-editable at this time
+* Widget.Device.widgetEngineProvider =&gt; Static non-editable at this time
+* Widget.Device.widgetEngineVersion =&gt; Static non-editable at this time
+* Widget.Device.getAvailableApplications =&gt; Static non-editable at this time
+* Widget.Device.launchApplication
+* Widget.Device.AccountInfo.phoneUserUniqueId =&gt; Static non-editable at this time
+* Widget.Device.AccountInfo.phoneMSISDN =&gt; Static non-editable at this time
+* Widget.Device.AccountInfo.phoneOperatorName =&gt; Static non-editable at this time
+* Widget.Device.AccountInfo.userAccountBalance =&gt; Static non-editable at this time
+* Widget.Device.AccountInfo.userSubscriptionType =&gt; Static non-editable at this time
+* Widget.Device.DeviceStateInfo.onPositionRetrieved
+* Widget.Device.DeviceStateInfo.requestPositionInfo
+* Widget.Device.PositionInfo
+* Widget.Device.RadioInfo.RadioSignalSourceTypes
+* Widget.Device.ApplicationTypes


### PR DESCRIPTION
Just working on porting rippledocs to the blackberry/Ripple-UI Wiki, which included porting the changelog. In this case I included it in doc/ vs cluttering the root. After this I will publish an update to rippledocs pointing to the new location.

Currently, I ported the whole thing (i.e. from v0.1.0 onward). I figure if the size really becomes an issue we can archive some of it.
