### PR TITLE
Fix for issue #234

### DIFF
--- a/lib/ripple/platform/webworks.core/2.0.0/fsCache.js
+++ b/lib/ripple/platform/webworks.core/2.0.0/fsCache.js
@@ -180,8 +180,8 @@ _self = {
             fs.stat(path, function () {}, _fsError);
 
             return new FileProperties({
-                dateCreated: entry.properties.lastModifiedDate,
-                dateModified: entry.properties.lastModifiedDate,
+                dateCreated: entry.lastModifiedDate,
+                dateModified: entry.lastModifiedDate,
                 directory: info.parent,
                 fileExtension: info.extension,
                 isHidden: info.hidden,


### PR DESCRIPTION
Web inspector shows the value of lastModifiedDate exists on the 'entry' object and not in 'entry.property'
