### PR TITLE
Crx.update.url

### DIFF
--- a/build/build/chromium.js
+++ b/build/build/chromium.js
@@ -29,7 +29,8 @@ module.exports = function (src, baton) {
         var css = _c.ASSETS + "ripple.css",
             cssDeploy = _c.DEPLOY + "chromium/ripple.css",
             manifest = _c.DEPLOY + "chromium/manifest.json",
-            updates = _c.DEPLOY + "chromium/updates.xml",
+            updatesSrc = _c.DEPLOY + "chromium/updates.xml",
+            updatesDeploy = _c.DEPLOY + "updates.xml",
             js = _c.DEPLOY + "chromium/ripple.js",
             bootstrap = _c.DEPLOY + "chromium/bootstrap.js",
             doc = src.html.replace(/#OVERLAY_VIEWS#/g, src.overlays)
@@ -43,7 +44,9 @@ module.exports = function (src, baton) {
         fs.writeFileSync(manifest, fs.readFileSync(manifest, "utf-8")
                          .replace(new RegExp('"version": ""', 'g'), '"version": "' + src.info.version + '"'));
 
-        fs.unlinkSync(updates); // updates.xml is for the server, not the extension
+        fs.writeFileSync(updatesDeploy, fs.readFileSync(updatesSrc, "utf-8")
+                         .replace(new RegExp('version=""', 'g'), 'version="' + src.info.version + '"'));
+        fs.unlinkSync(updatesSrc);
 
         fs.writeFileSync(bootstrap,
                          "window.th_panel = {" + "LAYOUT_HTML: '" + doc + "'};" +

--- a/build/build/chromium.js
+++ b/build/build/chromium.js
@@ -29,6 +29,7 @@ module.exports = function (src, baton) {
         var css = _c.ASSETS + "ripple.css",
             cssDeploy = _c.DEPLOY + "chromium/ripple.css",
             manifest = _c.DEPLOY + "chromium/manifest.json",
+            updates = _c.DEPLOY + "chromium/updates.xml",
             js = _c.DEPLOY + "chromium/ripple.js",
             bootstrap = _c.DEPLOY + "chromium/bootstrap.js",
             doc = src.html.replace(/#OVERLAY_VIEWS#/g, src.overlays)
@@ -41,6 +42,8 @@ module.exports = function (src, baton) {
 
         fs.writeFileSync(manifest, fs.readFileSync(manifest, "utf-8")
                          .replace(new RegExp('"version": ""', 'g'), '"version": "' + src.info.version + '"'));
+
+        fs.unlinkSync(updates); // updates.xml is for the server, not the extension
 
         fs.writeFileSync(bootstrap,
                          "window.th_panel = {" + "LAYOUT_HTML: '" + doc + "'};" +

--- a/ext/chromium/manifest.json
+++ b/ext/chromium/manifest.json
@@ -27,5 +27,5 @@
     "description": "A browser based html5 mobile application development and testing tool",
     "file_name": "manifest.json",
     "update_page": "update.html",
-    "update_url": "http://wbt20ykf/html5/extensiontest/updates.xml"
+    "update_url": "http://developer.blackberry.com/ripple/updates.xml"
 }

--- a/ext/chromium/manifest.json
+++ b/ext/chromium/manifest.json
@@ -23,7 +23,7 @@
         "matches": ["http://*/*","https://*/*","file:///*"],
         "all_frames": true
     }],
-    "permissions": ["tabs", "unlimitedStorage", "notifications", "contextMenus", "webRequest", "webRequestBlocking", "http://*/*", "https://*/*"],
+    "permissions": ["tabs", "unlimitedStorage", "notifications", "contextMenus", "webRequest", "http://*/*", "https://*/*"],
     "description": "A browser based html5 mobile application development and testing tool",
     "file_name": "manifest.json",
     "update_page": "update.html"

--- a/ext/chromium/manifest.json
+++ b/ext/chromium/manifest.json
@@ -26,5 +26,6 @@
     "permissions": ["tabs", "unlimitedStorage", "notifications", "contextMenus", "webRequest", "webRequestBlocking", "http://*/*", "https://*/*"],
     "description": "A browser based html5 mobile application development and testing tool",
     "file_name": "manifest.json",
-    "update_page": "update.html"
+    "update_page": "update.html",
+    "update_url": "http://wbt20ykf/html5/extensiontest/updates.xml"
 }

--- a/ext/chromium/manifest.json
+++ b/ext/chromium/manifest.json
@@ -23,7 +23,7 @@
         "matches": ["http://*/*","https://*/*","file:///*"],
         "all_frames": true
     }],
-    "permissions": ["tabs", "unlimitedStorage", "notifications", "contextMenus", "webRequest", "http://*/*", "https://*/*"],
+    "permissions": ["tabs", "unlimitedStorage", "notifications", "contextMenus", "webRequest", "webRequestBlocking", "http://*/*", "https://*/*"],
     "description": "A browser based html5 mobile application development and testing tool",
     "file_name": "manifest.json",
     "update_page": "update.html"

--- a/ext/chromium/updates.xml
+++ b/ext/chromium/updates.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='utf-8'?>
-<gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
-  <app appid='cnijnnaimeaacneklcndcafbnkeicckh'>
-    <updatecheck codebase='http://developer.blackberry.com/ripple/ripple_ui.crx' version='0.9.5' />
+<?xml version="1.0" encoding="utf-8"?>
+<gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
+  <app appid="cnijnnaimeaacneklcndcafbnkeicckh">
+    <updatecheck codebase="http://developer.blackberry.com/ripple/ripple_ui.crx" version="" />
   </app>
 </gupdate>

--- a/ext/chromium/updates.xml
+++ b/ext/chromium/updates.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='cnijnnaimeaacneklcndcafbnkeicckh'>
-    <updatecheck codebase='http://wbt20ykf/html5/extensiontest/ripple_ui.crx' version='0.9.5' />
+    <updatecheck codebase='http://developer.blackberry.com/ripple/ripple_ui.crx' version='0.9.5' />
   </app>
 </gupdate>

--- a/ext/chromium/updates.xml
+++ b/ext/chromium/updates.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='utf-8'?>
+<gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+  <app appid='cnijnnaimeaacneklcndcafbnkeicckh'>
+    <updatecheck codebase='http://wbt20ykf/html5/extensiontest/ripple_ui.crx' version='0.9.5' />
+  </app>
+</gupdate>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "A browser based html5 mobile application development and testing tool",
   "homepage": "http://github.com/blackberry/Rippe-UI",
   "author": {


### PR DESCRIPTION
This adds the production 'update-url' to the manifest, and adds a new 'updates.xml' file that we can publish alongside the corresponding CRX at the production URL when updates become available in future releases. This pull request also updates the product version number to 0.9.5.
