### PR TITLE
bumping version to x.y.z style that npm prefers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple",
-  "version": "0.9.6.1",
+  "version": "0.9.7",
   "description": "A browser based html5 mobile application development and testing tool",
   "homepage": "http://github.com/blackberry/Rippe-UI",
   "author": {


### PR DESCRIPTION
otherwise NPM will error out and not install all dependencies when you run ./configure (due to current version in package.json being 0.9.6.1)
