### PR TITLE
`jake test` does not exit properly.

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -22,10 +22,29 @@ task('build', [], require('./build/build'));
 desc("test and lint before building (with js compression)");
 task('deploy', [], require('./build/deploy'));
 
+// TODO: put this functionality into its own module (same with code in build/deploy).
 desc("run all tests in node with an emulated dom - jake test [path,path2]");
 task('test', [], function () {
-    require('./build/test')(null, process.argv.length >= 4 ? process.argv[3] : null);
-});
+    var childProcess = require('child_process'),
+        env = process.env,
+        lib = process.cwd() + '/lib',
+        script = process.cwd() + '/build/scripts/runTestsInNode',
+        child;
+
+    env.NODE_PATH = lib;
+    child = childProcess.spawn(process.execPath, [script], {'env': env});
+
+    function log(data) {
+        process.stdout.write(new Buffer(data).toString('utf-8'));
+    }
+
+    child.stdout.on('data', log);
+    child.stderr.on('data', log);
+    child.on('exit', function (code) {
+        complete();
+        process.exit(code);
+    });
+}, true);
 
 desc("boot test server for running all tests in the browser");
 task('btest', [], require('./build/btest'));

--- a/build/deploy.js
+++ b/build/deploy.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var test = require('./test'),
-    lint = require('./lint'),
+var lint = require('./lint'),
     build = require('./build'),
+    childProcess = require('child_process'),
     fs = require('fs'),
     fail = fs.readFileSync(__dirname + "/../thirdparty/fail.txt", "utf-8");
 
@@ -24,6 +24,26 @@ function ok(code) {
         process.stdout.write(fail);
         process.exit(1);
     }
+}
+
+function test(callback) {
+    var env = process.env,
+        lib = process.cwd() + '/lib',
+        script = process.cwd() + '/build/scripts/runTestsInNode',
+        child;
+
+    env.NODE_PATH = lib;
+    child = childProcess.spawn(process.execPath, [script], {'env': env});
+
+    function log(data) {
+        process.stdout.write(new Buffer(data).toString('utf-8'));
+    }
+
+    child.stdout.on('data', log);
+    child.stderr.on('data', log);
+    child.on('exit', function (code) {
+        callback(code);
+    });
 }
 
 module.exports = function () {

--- a/build/scripts/runTestsInNode
+++ b/build/scripts/runTestsInNode
@@ -1,0 +1,5 @@
+// This is here for a reason.
+// This is so you can do things like `NODE_PATH=/path/to/ripple/lib node external_script`.
+// This gets around that pesky forcing of relative requires in Node (these days).
+// See the `jakefile` for how this is used in this project.
+require('./../test')();

--- a/build/test.js
+++ b/build/test.js
@@ -66,13 +66,11 @@ function _setupEnv(ready) {
 
         _extraMocks();
 
-        childProcess.exec('rm -rf node_modules/ripple* && ' +
-                          'cp -rf lib/ripple node_modules/ripple && ' +
-                          'cp -f lib/ripple.js node_modules/ripple.js', ready);
+        ready();
     });
 }
 
-module.exports = function (done, custom) {
+module.exports = function (done) {
     //HACK: this should be  taken out if our pull request in jasmine is accepted.
     jasmine.core.Matchers.prototype.toThrow = function (expected) {
         var result = false,
@@ -108,14 +106,11 @@ module.exports = function (done, custom) {
     };
 
     _setupEnv(function () {
-        var targets = __dirname + "/../" + (custom ? custom : "test");
+        var targets = __dirname + "/../test";
 
         jasmine.run(targets.split(' '), function (runner) {
             var failed = runner.results().failedCount === 0 ? 0 : 1;
-            //Nuke everything out of node_modules since it was just in there to run the tests
-            childProcess.exec('rm -rf node_modules/ripple*', function () {
-                (typeof done !== "function" ? process.exit : done)(failed);
-            });
+            (typeof done !== "function" ? process.exit : done)(failed);
         });
     });
 };


### PR DESCRIPTION
This causes some major issues, such as `jake deploy` not working. The
tests run fine, but there is a really weird error that happens after
attempting to `rm -rf node_modules/ripple*` (which is a hack). This
started happening randomly, so it seemed easier to remove the need for
such a hack in the first place, vs continuing to figure out the error.

This solution feels better, as well.. and YES, it does use two
instances of node to test now. There is a _slight_ performance hit,
but it is barely noticeable.

GitHub Issue #428
