### PR TITLE
Fix for GPX File Replay FileReader

### DIFF
--- a/lib/ripple.js
+++ b/lib/ripple.js
@@ -17,6 +17,7 @@ var omgwtf = require('ripple/omgwtf'),
     db = require('ripple/db'),
     xhr = require('ripple/xhr'),
     geo = require('ripple/geo'),
+    fr = require('ripple/FileReader'),
     fs = require('ripple/fs'),
     platform = require('ripple/platform'),
     emulatorBridge = require('ripple/emulatorBridge'),
@@ -67,6 +68,7 @@ var omgwtf = require('ripple/omgwtf'),
                  .andThen(db.initialize, db)
                  .andThen(xhr.initialize, xhr)
                  .andThen(geo.initialize, geo)
+                 .andThen(fr.initialize, fr)
                  .andThen(fs.initialize, fs)
                  .andThen(platform.initialize, platform)
                  .andThen(devices.initialize, devices)

--- a/lib/ripple/FileReader.js
+++ b/lib/ripple/FileReader.js
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2011 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var _orig;
+
+module.exports = {
+    initialize: function () {
+        _orig = window.FileReader;
+    },
+    createReader: function () {
+        return new _orig();
+    }
+};
+    

--- a/lib/ripple/cssMediaQueryEmulator.js
+++ b/lib/ripple/cssMediaQueryEmulator.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 var utils = require('ripple/utils'),
-    constants = require('ripple/constants'),
     emulateRules,
     transforms = {
         "-webkit-device-pixel-ratio": {

--- a/lib/ripple/ui/plugins/geoView.js
+++ b/lib/ripple/ui/plugins/geoView.js
@@ -216,7 +216,7 @@ module.exports = {
         }
 
         function loadGpxFile(win, fail, args) {
-            var reader = new FileReader(),
+            var reader = require('ripple/FileReader').createReader(),
                 file = args[0],
                 _xml,
                 t,
@@ -234,7 +234,6 @@ module.exports = {
                 _speed = 0,
                 _dist = 0,
                 navUtils = new utils.navHelper();
-
             reader.onload = function (e) {
                 _xml = e.target.result;
                 t = $(_xml).find('trkpt');


### PR DESCRIPTION
Original code used window.FileReader which has been overridden with the cordova FileReader in Ripple using Cordova 2.0.  Changed code to point to Chrome's FileReader.
