### PR TITLE
HTML and CSS files are not minified on deploy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "dependencies": {
     "connect": "2.3.6",
     "jsdom": "0.2.14",
-    "jWorkflow": "*"
+    "jWorkflow": "*",
+    "cssmin": "0.3.1",
+    "html-minifier": "0.4.5"
   },
   "bundledDependencies": [
     "connect"


### PR DESCRIPTION
This adds CSS/HTML compression (and comment removal) to the compress
build task (used in `jake deploy`).

This adds two new (local) NPM modules: (i.e. not being "shipped" with code)
- http://npmjs.org/package/cssmin
- http://npmjs.org/package/html-minifier

This also address this GitHub Issue:
https://github.com/blackberry/Ripple-UI/issues/213
