### PR TITLE
There needs to be support for Chrome's extension manifest v2.

### DIFF
--- a/ext/chromestore/manifest.json
+++ b/ext/chromestore/manifest.json
@@ -1,14 +1,18 @@
 {
     "version": "",
+    "manifest_version": 2,
     "name": "Ripple Emulator (Beta)",
-    "background_page":"views/background.html",
+    "background": {
+        "page": "views/background.html"
+    },
+    "web_accessible_resources": [],
     "icons":{
         "16":"images/Icon_16x16.png",
         "128":"images/Icon_128x128.png",
         "48":"images/Icon_48x48.png"
     },
     "browser_action":{
-        "popup":"views/popup.html",
+        "default_popup":"views/popup.html",
         "default_icon":"images/Icon_48x48.png",
         "default_title":"Ripple"
     },

--- a/ext/chromium/controllers/update.js
+++ b/ext/chromium/controllers/update.js
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2012 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+window.addEventListener("load", function () {
+    var metaData = chrome.extension.getBackgroundPage().tinyHippos.Background.metaData(),
+        title = metaData.justInstalled ? "Welcome to Ripple" : "Ripple has been updated",
+        body = "";
+
+    document.getElementById("title").innerText = title;
+        
+    if (metaData.justInstalled) {
+        body = "Visit our <a href=\"http://developer.blackberry.com/html5/documentation\" target=\"_blank\">documentation site</a> to get started.";
+    } else {
+        body = "See what's new in <a href=\"https://github.com/blackberry/Ripple-UI/blob/master/doc/CHANGELOG.md\"" +
+            " target=\"_blank\">v" + metaData.version + "</a>.";
+    }
+
+    document.getElementById("body").innerHTML = body;
+});

--- a/ext/chromium/manifest.json
+++ b/ext/chromium/manifest.json
@@ -1,7 +1,11 @@
 {
     "version": "",
+    "manifest_version": 2,
     "name": "Ripple Emulator (Beta)",
-    "background_page":"views/background.html",
+    "background": {
+        "page": "views/background.html"
+    },
+    "web_accessible_resources": [],
     "plugins": [
         { "path": "plugins/npRippleBD.dll" },
         { "path": "plugins/RippleBD.plugin" }
@@ -12,7 +16,7 @@
         "48":"images/Icon_48x48.png"
     },
     "browser_action":{
-        "popup":"views/popup.html",
+        "default_popup":"views/popup.html",
         "default_icon":"images/Icon_48x48.png",
         "default_title":"Ripple"
     },

--- a/ext/chromium/views/update.html
+++ b/ext/chromium/views/update.html
@@ -19,25 +19,13 @@
         <title>Ripple Update</title>
         <link media="screen" rel="stylesheet" type="text/css" href="../styles/extension.css" />
         <link media="screen" rel="stylesheet" type="text/css" href="../themes/dark/theme.css" />
+        <script type="text/javascript" src="../controllers/update.js"></script>
     </head>
     <body>
         <div class="update-container" style="color: #F0F0F0">
             <img src="../images/Icon_48x48.png" class="notification-icon" alt="" />
-
-            <h2><script type="text/javascript" charset="utf-8">
-                var metaData = chrome.extension.getBackgroundPage().tinyHippos.Background.metaData();
-                document.write(metaData.justInstalled ? "Welcome to Ripple" : "Ripple has been updated");
-            </script></h2>
-            <p><script type="text/javascript" charset="utf-8">
-                var html = "";
-                if (metaData.justInstalled) {
-                    html = "Visit our <a href=\"http://developer.blackberry.com/html5/documentation\" target=\"_blank\">documentation site</a> to get started.";
-                } else {
-                    html = "See what's new in <a href=\"https://github.com/blackberry/Ripple-UI/blob/master/doc/CHANGELOG.md\"" +
-                        " target=\"_blank\">v" + metaData.version + "</a>.";
-                }
-                document.write(html);
-            </script></p>
+            <h2 id="title"></h2>
+            <p id="body"></p>
         </div>
     </body>
 </html>


### PR DESCRIPTION
This includes numerous fixes:
- Remove use of inline scripts in views/update.html.
- Support web_accessible_resouces key.
- Update `background_page` to new `background` property.
- Update `browser_action.popup` key name to `default_popup`.
