### PR TITLE
`utils.rippleLocation()` returns wrong value if path has "." in it.

### DIFF
--- a/lib/ripple/utils.js
+++ b/lib/ripple/utils.js
@@ -190,14 +190,15 @@ self = module.exports = {
 
     rippleLocation: function () {
         var loc = self.location(),
-            parts = loc.pathname.replace(/\/$/, "").split("/"),
+            parts = loc.pathname.split("/"),
             base = "",
             port = loc.port ? ":" + loc.port : "";
 
-        if (parts[parts.length - 1].indexOf(".") !== -1) {
+        if (parts[parts.length - 1].match(/\.\w*$/)) {
             parts = parts.splice(0, parts.length - 1);
         }
-        base = parts.join("/");
+
+        base = parts.join("/").replace(/\/$/, '');
 
         return loc.protocol + "//" + loc.hostname + port + base + "/";
     },

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -632,9 +632,7 @@ describe("utils", function () {
                 expect(utils.rippleLocation()).toBe("http://127.0.0.1:6767/i/will/put/ripple/here/");
             });
 
-            //Test for github issue #315
-            xit("returns the correct path when folder has a . in it", function () {
-                
+            it("returns the correct path when folder has a . in it", function () {
                 spyOn(utils, "location").andReturn({
                     href: "http://127.0.0.1/bb10.sample/",
                     protocol: "http:",


### PR DESCRIPTION
GitHub Issue:
https://github.com/blackberry/Ripple-UI/issues/315
