### PR TITLE
Updated two torch models (9810 and 9850/60) PPI numbers per RIM specs at...

### DIFF
--- a/lib/ripple/devices/Torch9810.js
+++ b/lib/ripple/devices/Torch9810.js
@@ -57,7 +57,7 @@ module.exports = {
         }
     },
 
-    "ppi": 249,
+    "ppi": 253,
     "userAgent": "Mozilla/5.0 (BlackBerry; U; BlackBerry 9810; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/7.0.0.0 Mobile Safari/534.1",
     "platforms": ["web", "cordova", "webworks.handset"]
 };

--- a/lib/ripple/devices/Torch9860-9850.js
+++ b/lib/ripple/devices/Torch9860-9850.js
@@ -57,7 +57,7 @@ module.exports = {
         }
     },
 
-    "ppi": 252,
+    "ppi": 253,
     "userAgent": "Mozilla/5.0 (BlackBerry; U; BlackBerry 9860; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/7.0.0.0 Mobile Safari/534.1",
     "platforms": ["web", "cordova", "webworks.handset"]
 };


### PR DESCRIPTION
... http://ca.blackberry.com/smartphones/blackberry-torch-9800-9810.html#/h:/smartphones/blackberry-torch-9800-9810/phone-specifications.html and http://ca.blackberry.com/smartphones/blackberry-torch-9850-9860.html#/h:/smartphones/blackberry-torch-9850-9860/phone-specifications.html
