### PR TITLE
bugfix on Cordova 2.0.0 FileWriter

### DIFF
--- a/lib/ripple/platform/cordova/2.0.0/bridge/file.js
+++ b/lib/ripple/platform/cordova/2.0.0/bridge/file.js
@@ -142,7 +142,10 @@ module.exports = {
 
         window.webkitResolveLocalFileSystemURL(root + path, function (entry) {
             entry.file(function (file) {
-                if (win) win(file);
+                if (win) {
+                    file.fullPath = path;
+                    win(file);
+                }
             }, function (err) {
                 if (fail) fail(err.code);
             });
@@ -241,7 +244,7 @@ module.exports = {
             bb = new BB();
 
         // Format source path
-        sourcepath = (file.fullPath ? file.fullPath : '') + file.name;
+        sourcepath = file;//(file.fullPath ? file.fullPath : '') + file.name;
         sourcepath = cleanPath(sourcepath);
 
         // Create a blob for the text to be written


### PR DESCRIPTION
when writing to a file with a parent directory, like:
filesystem://localhost/PERSISTENT/test/test.txt

current code will lose the parent directories, and will generate a same-name file in the root directory:
filesystem://localhost/PERSISTENT/test.txt

I've mentioned this problem at:
https://github.com/blackberry/Ripple-UI/issues/577
