### PR TITLE
A (client side) `require` could instead use `ripple` (for consistency).

### DIFF
--- a/lib/client/platform/cordova/2.0.0/bridge/capture.js
+++ b/lib/client/platform/cordova/2.0.0/bridge/capture.js
@@ -24,7 +24,7 @@ module.exports = {
             success([file]);
         });
         event.once("image-capture-cancelled", function () {
-            error({code: require('ripple/client/emulatorBridge').window().CaptureError.CAPTURE_NO_MEDIA_FILES });
+            error({code: ripple('emulatorBridge').window().CaptureError.CAPTURE_NO_MEDIA_FILES });
         });
         camera.show();
     }


### PR DESCRIPTION
This is not a bug, just an attempt to keep a consistent way of requiring
modules in the client (browser based) code.
