### PR TITLE
Throw a helpful error when registering for an unsupported (BB10) event.

### DIFF
--- a/lib/client/platform/webworks.bb10/1.0.0/event.js
+++ b/lib/client/platform/webworks.bb10/1.0.0/event.js
@@ -195,6 +195,10 @@ module.exports = {
     addEventListener: function (type, func) {
         this.removeEventListener(type, func);
 
+        if (!events[type]) {
+            throw new Error("Cannot register a handler for the " + type + " event, because it does not seem to be supported.");
+        }
+
         if (!app.getInfo().features || app.getInfo().features[events[type].feature]) {
             events[type].callbacks.push(func);
         }
@@ -205,7 +209,8 @@ module.exports = {
     },
 
     removeEventListener: function (type, func) {
-        var idx = events[type].callbacks.indexOf(func);
+        var idx = events[type] ? events[type].callbacks.indexOf(func) : -1;
+
         if (idx >= 0) {
             delete events[type].callbacks[idx];
         }


### PR DESCRIPTION
Take this example:

```
blackberry.event.addEventListener("onaccesschanged", function () {})
```

If an unsupported event name is registered for, it would throw an error
like this:

```
Uncaught TypeError: Cannot read property 'callbacks' of undefined.
```

Now, it will throw a `new Error(..)` with a message like this:

```
Uncaught Error: Cannot register a handler for the onaccesschanged
event, because it does not seem to be supported.
```

This commit is related (but does not fix) to this GitHub issue:

```
https://github.com/blackberry/Ripple-UI/issues/629
```
