### PR TITLE
`request.pipe` better handles proxying (xhr) requests (in general).

### DIFF
--- a/lib/server/proxy.js
+++ b/lib/server/proxy.js
@@ -79,26 +79,26 @@ function proxy(req, res, callback) {
             proxyReqData.form = req.body;
         }
 
-        request(proxyReqData, function (error, response, body) {
-            if (error) {
-                console.log("ERROR:".red + " Proxying failed with:");
-                console.log(error);
-                res.send(500, error);
-            } else {
-                callback(response, body);
-            }
-        });
+        if (callback) {
+            request(proxyReqData, function (error, response, body) {
+                if (error) {
+                    console.log("ERROR:".red + " Proxying failed with:");
+                    console.log(error);
+                    res.send(500, error);
+                } else {
+                    callback(response, body);
+                }
+            });
+        } else {
+            request(proxyReqData).pipe(res);
+        }
     } else {
         res.send(200, "You shall not pass!");
     }
 }
 
 function xhrProxyHandler(req, res/*, next*/) {
-    proxy(req, res, function callback(response, body) {
-        res.status(response.statusCode);
-        res.set(response.headers);
-        res.send(body);
-    });
+    proxy(req, res);
 }
 
 function jsonpXHRProxyHandler(req, res/*, next*/) {


### PR DESCRIPTION
As noticed in work (in another branch):

When directly handling the body object via the `request` callback
method, handling some use cases (ex. raw streams) are being returned
as corrupted content (ex. a png image).

The pipe method is ideal, as it allows the proxy to be done without
manually dealing with encoding, etc, as well as ending the response.

However, only when there is no callback given should pipe be used, as
proxies like the jsonp xhr handler (when running on file:///) still
needs to reply with different content.

Note: It _may_ be that `request` is at fault here, or just missing a
feature. Since pipe seems to be the best thing to use (in
retrospect), it seems practical and most time considerate to fix here,
and look to investigate if it is an issue later on (if possible).
