### PR TITLE
The cross origin XHR proxy does not entirely handle errors (gracefully).

### DIFF
--- a/lib/server/proxy.js
+++ b/lib/server/proxy.js
@@ -50,7 +50,8 @@ function getUserAgent(req, proxyReqHeaders) {
 function proxy(req, res, callback) {
     var parsedURL = url.parse(unescape(req.query.tinyhippos_rurl)),
         proxyReqData,
-        proxyReqHeaders;
+        proxyReqHeaders,
+        proxyReq;
 
     if (authenticated(req.query.tinyhippos_apikey)) {
         console.log("INFO:".green + " Proxying cross origin XMLHttpRequest - " + parsedURL.href);
@@ -79,18 +80,24 @@ function proxy(req, res, callback) {
             proxyReqData.form = req.body;
         }
 
-        if (callback) {
-            request(proxyReqData, function (error, response, body) {
+        // Attempt to catch any sync errors
+        try {
+            proxyReq = request(proxyReqData, function (error, response, body) {
                 if (error) {
-                    console.log("ERROR:".red + " Proxying failed with:");
-                    console.log(error);
+                    console.log("ERROR:".red + " Proxying failed with:", error);
                     res.send(500, error);
-                } else {
+                } else if (callback) {
                     callback(response, body);
                 }
             });
-        } else {
-            request(proxyReqData).pipe(res);
+
+            // If no callback, use pipe (which means body & response objects are not needed post-request)
+            // The callback in request(... function (error) {}) (above) is still called when node http client hits unrecoverable error
+            if (!callback) {
+                proxyReq.pipe(res);
+            }
+        } catch (e) {
+            res.send(500, e.toString());
         }
     } else {
         res.send(200, "You shall not pass!");


### PR DESCRIPTION
When it was initially created (i.e. re-written) this was an oversight
that was made (as it seemed quite solid). This is not true. Stuff can go
bad (especially if server errors out continually)... so, let's fix it!

There are two ways errors can happen.
1. Synchronously thrown errors when initializing a client request.

Example: passing an invalid URI (i.e. a local '/foo/bar' url) will
cause an exception to be thrown (which could possibly crash the app).
1. Errors during the (async) request itself (notified via error event).

Example: Passing in a URL that fails during DNS lookup will raise an
`error` on the client request object (ex: http://googleeee.com).

Note: Since errors were already captured by `request` and passed
into the callback (as you can see), the XHR proxy already gracefully
handled errors, but that was never taken advantage of when using
`request.pipe`. This cleans that up so it always look for an error
object and responds with a 500 (and error message), if so.
