### PR TITLE
There is lack of CORS support for certain HTTP verbs.

### DIFF
--- a/lib/server/proxy.js
+++ b/lib/server/proxy.js
@@ -132,7 +132,7 @@ function jsonpXHRProxyHandler(req, res/*, next*/) {
 function start(options, app) {
     var corsOptions = {
         origins: ["*"],
-        methods: ['HEAD', 'GET', 'POST'],
+        methods: ['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'TRACE', 'CONNECT'],
         credentials: true,
         headers: []
     };


### PR DESCRIPTION
This (presumably) adds support for the rest of the verbs, which were
left out when the proxy was re-written :-( (there definitely could have
been more testing in place for this, alas, resources..).

This fixes GitHub issue:

https://github.com/blackberry/Ripple-UI/issues/693
