### PR TITLE
Cross origin (JSON based) XHR proxy requests are not forwarded properly.

### DIFF
--- a/lib/server/proxy.js
+++ b/lib/server/proxy.js
@@ -77,7 +77,11 @@ function proxy(req, res, callback) {
         };
 
         if (Object.keys(req.body).length > 0) {
-            proxyReqData.form = req.body;
+            if (req.get("content-type") === "application/json") {
+                proxyReqData.body = JSON.stringify(req.body);
+            } else {
+                proxyReqData.form = req.body;
+            }
         }
 
         // Attempt to catch any sync errors


### PR DESCRIPTION
The bodyParser middleware would parse the JSON properly, however the
`form` option in `request` was being used, and it was sent as a
'application/x-www-form-urlencoded' request. Instead it should be
stringified and set to the `request`'s `body` option.

This fixes another issue pointed out in:

https://github.com/blackberry/Ripple-UI/issues/693
