### PR TITLE
There is no JS test coverage for this project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pkg
 /plugins
 services
 npm-debug.log
+test/assets/cov/results.html

--- a/Jakefile
+++ b/Jakefile
@@ -30,6 +30,13 @@ task('test', [], function () {
                 Array.prototype.slice.apply(arguments) : null);
 });
 
+namespace('test', function () {
+    desc("runs jake test with code coverage");
+    task('cov', [], function (customPaths) {
+        require('./build/test/cov')(customPaths, complete);
+    }, true);
+});
+
 desc("boot test server for running all tests in the browser");
 task('btest', [], require('./build/btest'));
 

--- a/build/test.js
+++ b/build/test.js
@@ -72,7 +72,9 @@ function _setupEnv(ready) {
     });
 }
 
-module.exports = function (customPaths, done) {
+module.exports = function (customPaths, done, opts) {
+    if (!opts) { opts = {}; }
+
     //HACK: this should be  taken out if our pull request in jasmine is accepted.
     jasmine.core.Matchers.prototype.toThrow = function (expected) {
         var result = false,
@@ -120,7 +122,8 @@ module.exports = function (customPaths, done) {
         }
 
         global.ripple = function (p) {
-            return require(path.normalize(path.join(__dirname, "..", "lib", "client")) + "/" + p);
+            return require(path.normalize(path.join(__dirname, "..",
+                        (opts.withCoverage ? path.join("cov", "lib") : "lib"), "client")) + "/" + p);
         };
 
         jasmine.run(targets, function (runner) {

--- a/build/test/cov.js
+++ b/build/test/cov.js
@@ -1,0 +1,52 @@
+var childProcess = require('child_process'),
+    fs = require('fs'),
+    path = require('path'),
+    connect = require('connect'),
+    test = require('./../test'),
+    reporter = require('./cov/reporter'),
+    coverjs = __dirname + "/../../node_modules/coverjs/bin/cover.js",
+    _coveragePort = 7070,
+    _coverageAssets = __dirname + '/../../test/assets/cov';
+        
+function instrument(callback) {
+    var args = ["-r", "-o", "cov", "lib", "test", "-e", "test/assets/cov"],
+        cmd = childProcess.spawn(coverjs, args);
+    cmd.on("exit", callback);
+}
+
+function serveUpResults() {
+    var indexHtml = fs.readFileSync(path.join(_coverageAssets, 'results.html'), "utf-8")
+                          .replace(/<\/head>/i,
+                                      '<link rel="stylesheet" href="style.css" />' +
+                                      '<script src="pretty.js"></script>' +
+                                   "</head>");
+
+    connect
+        .createServer()
+        .use(connect.static(_coverageAssets))
+        .use("/", function (req, res) { res.end(indexHtml); })
+        .listen(_coveragePort, function () {
+            console.log("  coverage results at");
+            console.log("    http://127.0.0.1:" + _coveragePort);
+            console.log();
+        });
+}
+
+function cleanup(callback) {
+    childProcess.exec('rm -rf cov/', callback);
+}
+
+module.exports = function (customPaths, done) {
+    instrument(function () {
+        global.__$coverObject = {}; // global.window trips up use of global.__$coverObject being used
+
+        test(customPaths || ["cov/test"], function () {
+            console.log("Generating coverage report...");
+            console.log();
+
+            cleanup(function () {
+                reporter.report(serveUpResults, done);
+            });
+        }, {withCoverage: true});
+    });
+};

--- a/build/test/cov/reporter.js
+++ b/build/test/cov/reporter.js
@@ -1,0 +1,33 @@
+var fs = require('fs'),
+    HTMLReporter = require('./../../../node_modules/coverjs/lib/reporters/HTMLReporter'),
+    resultsFile = __dirname + '/../../../test/assets/cov/results.html';
+
+function report(done) {
+    var html = new HTMLReporter(global.__$coverObject),
+        reportHTML = html.report(),
+        coveragePercent = Math.round((html.pass / html.total) * 100);
+
+    reportHTML = reportHTML.replace(/<body>/g,
+                            '<body style="display: none;">' +
+                               '<div class="totals">' +
+                                 '<div class="total-coverage">' + coveragePercent + "% coverage</div>" +
+                                 '<div class="total-statements">' + html.total + " statements</div>" +
+                                 '<div class="total-covered">' + html.pass + " covered</div>" +
+                                 '<div class="total-skipped">' + html.error + " skipped</div>" +
+                               '</div>');
+
+    fs.writeFileSync(resultsFile, reportHTML, 'utf-8');
+
+    console.log('  Total Coverage      ' + coveragePercent + '%');
+    console.log();
+    console.log('  Statements          ' + html.total);
+    console.log('    Covered           ' + html.pass);
+    console.log('    Skipped           ' + html.error);
+    console.log();
+
+    done();
+}
+
+module.exports = {
+    report: report
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "cssmin": "0.3.1",
     "html-minifier": "0.4.5",
     "jWorkflow": "0.x.x",
-    "xmlhttprequest": "1.4.2"
+    "xmlhttprequest": "1.4.2",
+    "coverjs": "0.0.14"
   },
   "files": [
     "README.md",

--- a/test/assets/cov/pretty.js
+++ b/test/assets/cov/pretty.js
@@ -1,0 +1,40 @@
+window.addEventListener('load', function () {
+    var filedata = [];
+
+    function asc(a, b) {
+        return a.h1.innerHTML < b.h1.innerHTML ? -1 :
+            (a.h1.innerHTML > b.h1.innerHTML ? 1 : 0);
+    }
+
+    Array.prototype.forEach
+        .call(document.querySelectorAll('h1'), function (el) {
+            filedata.push({
+                h1: el,
+                // This is pretty hacky.. might break at some point
+                pre: el.nextSibling.nodeName === "#text" ?
+                    el.nextSibling.nextSibling : el.nextSibling
+            });
+        });
+
+    filedata = filedata.sort(asc);
+
+    filedata.forEach(function (el) {
+        var frag = document.createDocumentFragment();
+
+        frag.appendChild(el.h1);
+        frag.appendChild(el.pre);
+
+        document.body.appendChild(frag);
+    });
+
+    setTimeout(function () {
+        filedata.forEach(function (el) {
+            el.h1.addEventListener('click', function () {
+                var klass = el.pre.getAttribute('class') !== 'viewable' ? 'viewable' : '';
+                el.pre.setAttribute('class', klass);
+            });
+        });
+
+        document.body.setAttribute("style", "display: block;");
+    }, 100);
+});

--- a/test/assets/cov/style.css
+++ b/test/assets/cov/style.css
@@ -1,0 +1,91 @@
+h1 {
+    cursor: pointer;
+    color: #002B36;
+    font-size: 14px;
+    padding: 0;
+    margin: 0;
+    font-weight: normal;
+}
+
+h1:hover {
+    text-decoration: underline;
+}
+
+h1:active {
+    color: #839496;
+}
+
+h2, h3 {
+    font-size: 14px;
+    padding: 0;
+    margin: 0;
+}
+
+span, pre {
+    font: Monospace;
+    font-size: 12px;
+    background-color: #002B36;
+    color: #999999;
+}
+
+pre {
+    height: 0;
+    overflow: hidden;
+    margin: 0 2em;
+    padding: 0;
+    border-radius: 8px;
+}
+
+    .viewable {
+        padding: 1em;
+        margin: 1em 2em;
+        height: auto;
+    }
+
+.error {
+    background-color: #333333;
+}
+
+.count {
+    opacity: 0.8;
+    position: relative;
+    left: -0.25em;
+    padding-right: .2em;
+    padding-left: .2em;
+}
+
+    .pass .count {
+        background: transparent;
+        color: #BFFFBF;
+    }
+
+    .error .count {
+        background: transparent;
+        color: #F8D5D8;
+    }
+
+.totals {
+    float: right;
+    color: #839496;
+    padding: 1em;
+    margin: 1em 2em;
+    font-size: 14px;
+    background-color: #002B36;
+    border-radius: 8px;
+}
+
+    .totals div {
+        opacity: 0.8;
+    }
+
+    .total-coverage {
+        color: #BFFFBF;
+    }
+
+    .total-covered {
+        color: #BFFFBF;
+    }
+
+    .total-skipped {
+        color: #F8D5D8;
+    }


### PR DESCRIPTION
Usage: `jake test:cov`

This uses CoverJS: https://github.com/arian/CoverJS

When you run `jake test:cov`, `test` and `lib` code is instrumented and
copied to a `cov` directory in the root of the project, and executed.
When they have completed, a web based report is generated for viewing.

Note: This is a first pass at creating insight into the test coverage
for this project, and could be added onto (or even changed), whichever
makes the most sense. i.e The web based report is hackily changed to
be easier to digest.

Note: This only works for the node based runner (and not `jake btest`).

ASF Mailing list thread -> http://markmail.org/search/?q=ripple#query:ripple%20list%3Aorg.apache.ripple.dev+page:1+mid:p32orgzw6qeqtqxj+state:results
