### PR TITLE
Device.proxy

### DIFF
--- a/doc/cli/device-proxy.md
+++ b/doc/cli/device-proxy.md
@@ -1,0 +1,17 @@
+# Synopsis
+
+    ripple device-proxy [--port xxxx] [--route xxxx]
+
+# Description
+
+    A device proxy, allowing for API calls to be proxied to a connected device, rather then emulated
+    by Ripple
+
+# Arguments
+
+* --port   the port to host the application on
+* --route  specify an optional path to prefix proxy routes with (ex: http://localhost:port/prefix/xhr_proxy)
+
+# Example usage
+
+    ripple device-proxy --port 1234

--- a/doc/cli/xhr-proxy.md
+++ b/doc/cli/xhr-proxy.md
@@ -1,6 +1,6 @@
 # Synopsis
 
-    ripple proxy [--port xxxx] [--route xxxx]
+    ripple xhr-proxy [--port xxxx] [--route xxxx]
 
 # Description
 
@@ -13,4 +13,4 @@
 
 # Example usage
 
-    ripple proxy --port 1234
+    ripple xhr-proxy --port 1234

--- a/lib/cli/device-proxy.js
+++ b/lib/cli/device-proxy.js
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2012 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var self,
+    deviceProxy = require('./../server/deviceProxy');
+
+self = {
+    call: function (opts) {
+        self.start(opts);
+    },
+    start: function (opts) {
+        deviceProxy.start(opts);
+    }
+};
+
+module.exports = self;

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -29,7 +29,7 @@ function lookup(command, subcommand, options) {
         module = require('./' + command);
     } catch (e) {
         console.error(('Unknown command: ' + command).red.bold);
-        console.log();
+        console.log(e);
         help.call();
         return;
     }

--- a/lib/cli/xhr-proxy.js
+++ b/lib/cli/xhr-proxy.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 var self,
-    proxy = require('./../server/proxy');
+    xhrProxy = require('./../server/xhrProxy');
 
 self = {
     call: function (opts) {
         self.start(opts);
     },
     start: function (opts) {
-        proxy.start(opts);
+        xhrProxy.start(opts);
     }
 };
 

--- a/lib/client/bootstrap.js
+++ b/lib/client/bootstrap.js
@@ -17,6 +17,7 @@ var _bound,
     _console = ripple('console'),
     ui = ripple('ui'),
     db = ripple('db'),
+    event = ripple('event'),
     _CURRENT_URL = "current-url";
 
 function _bindObjects(win, doc) {
@@ -71,6 +72,7 @@ function _post(src) {
     _console.log("Initialization Finished (Make it so.)");
 
     frame.onload = function () {
+        event.trigger('DocumentLoad');
         var bootLoader = document.querySelector("#emulator-booting"),
             id;
         if (bootLoader) {

--- a/lib/client/bootstrap.js
+++ b/lib/client/bootstrap.js
@@ -17,7 +17,6 @@ var _bound,
     _console = ripple('console'),
     ui = ripple('ui'),
     db = ripple('db'),
-    event = ripple('event'),
     _CURRENT_URL = "current-url";
 
 function _bindObjects(win, doc) {

--- a/lib/client/platform/cordova/2.0.0/bridge.js
+++ b/lib/client/platform/cordova/2.0.0/bridge.js
@@ -36,7 +36,7 @@ module.exports = {
         };
 
         try {
-            if (proxy.isAwesome()) {
+            if (proxy.hasConnectedDevice()) {
                 proxy.exec(success, fail, service, action, args);
             }
             else {

--- a/lib/client/platform/cordova/2.0.0/bridge.js
+++ b/lib/client/platform/cordova/2.0.0/bridge.js
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var _prompt = ripple('ui/plugins/exec-dialog');
+var _prompt = ripple('ui/plugins/exec-dialog'),
+    proxy = ripple('ui/plugins/deviceProxy');
 
 module.exports = {
     exec: function (success, fail, service, action, args) {
@@ -35,7 +36,12 @@ module.exports = {
         };
 
         try {
-            emulator[service][action](success, fail, args);
+            if (proxy.isAwesome()) {
+                proxy.exec(success, fail, service, action, args);
+            }
+            else {
+                emulator[service][action](success, fail, args);
+            }
         }
         catch (e) {
             console.log("missing exec:" + service + "." + action);

--- a/lib/client/platform/cordova/2.0.0/spec/ui.js
+++ b/lib/client/platform/cordova/2.0.0/spec/ui.js
@@ -16,6 +16,7 @@
 module.exports = {
     plugins: [
         "accelerometer",
+        "deviceProxy",
         "deviceSettings",
         "geoView",
         "widgetConfig",

--- a/lib/client/ui/plugins/deviceProxy.js
+++ b/lib/client/ui/plugins/deviceProxy.js
@@ -37,14 +37,12 @@ module.exports = {
                 socket.emit("set-role", "ripple");
                 socket.on("ready", function (device) {
                     ready = true;
-                    document.getElementById("device-proxy-connected").innerHtml = device;
+                    document.getElementById("device-proxy-connected").innerHTML = device;
                 });
             });
         };
-        
 
         document.body.appendChild(script);
-        
         document.getElementById("device-proxy-connect").addEventListener("click", function () {
             //do stuff
         });
@@ -64,7 +62,7 @@ module.exports = {
             }
         });
     },
-    
+
     isAwesome: function () {
         return ready;
     }

--- a/lib/client/ui/plugins/deviceProxy.js
+++ b/lib/client/ui/plugins/deviceProxy.js
@@ -20,6 +20,7 @@ var RIPPLE_URL = "device-proxy-ripple-url",
     callbacks = {},
     utils = ripple('utils'),
     db = ripple('db'),
+    event = ripple('event'),
     serviceURL = db.retrieve(RIPPLE_URL) || "http://localhost:4400",
     socket;
 
@@ -74,6 +75,7 @@ function connect() {
         });
         socket.on("disconnect", function () {
             show("device-proxy-error");
+            ready = false;
         });
 
     };
@@ -97,6 +99,13 @@ module.exports = {
         utils.bindAutoSaveEvent(serviceURL, function () {
             serviceURL = rippleURLSetting.value;
             db.save(RIPPLE_URL, serviceURL);
+        });
+
+        event.on('DocumentLoad', function() {
+            console.log('document has changed, deviceproxy knows this');
+            if (socket && ready) {
+                socket.emit('documentload');
+            }
         });
 
         connect();

--- a/lib/client/ui/plugins/deviceProxy.js
+++ b/lib/client/ui/plugins/deviceProxy.js
@@ -14,9 +14,59 @@
  * limitations under the License.
  */
 
-var ready = false,
+var RIPPLE_URL = "device-proxy-ripple-url",
+    DEVICE_URL = "device-proxy-device-url",
+    ready = false,
+    utils = ripple('utils'),
+    db = ripple('db'),
+    rippleURL = db.retrieve(RIPPLE_URL) || "http://localhost:4400",
+    deviceURL = db.retrieve(DEVICE_URL) || "http://localhost:4400",
     socket;
 
+function el(id) {
+    return document.getElementById(id);
+}
+
+function show(id) {
+    utils.forEach(el(id).parentNode.children, function (element) {
+        console.log(element);
+        if (element.id === id) {
+            element.style = "block";
+        }
+        else {
+            element.style.display = "none";
+        }
+    });
+}
+
+function connect() {
+    var script = document.createElement("script");
+
+    script.setAttribute("src", rippleURL + "/socket.io/socket.io.js");
+    script.onerror = function () {
+        show("device-proxy-error");
+    };
+    script.onload = function () {
+        socket = io.connect(rippleURL);
+        socket.on("connect", function () {
+            show("device-proxy-device-not-connected");
+            socket.emit("set-role", "ripple");
+            socket.on("ready", function (device) {
+                ready = true;
+                show("device-proxy-device-connected");
+                el("device-proxy-connected-device").innerHTML = device;
+            });
+            socket.on("device-disconnected", function (data) {
+                show("device-proxy-device-not-connected");
+            });
+        });
+        socket.on("disconnect", function () {
+            show("device-proxy-error");
+        });
+    };
+
+    document.body.appendChild(script);
+}
 module.exports = {
     panel: {
         domId: "device-proxy-container",
@@ -25,27 +75,20 @@ module.exports = {
     },
 
     initialize: function () {
-        var script = document.createElement("script");
+        var deviceURLSetting = el(DEVICE_URL),
+            rippleURLSetting = el(RIPPLE_URL);
 
-        script.setAttribute("src", location.origin + "/socket.io/socket.io.js");
-        script.onerror = function () {
-            fail();
-        };
-        script.onload = function () {
-            socket = io.connect(location.origin);
-            socket.on("connect", function () {
-                socket.emit("set-role", "ripple");
-                socket.on("ready", function (device) {
-                    ready = true;
-                    document.getElementById("device-proxy-connected").innerHTML = device;
-                });
-            });
-        };
-
-        document.body.appendChild(script);
-        document.getElementById("device-proxy-connect").addEventListener("click", function () {
-            //do stuff
+        utils.bindAutoSaveEvent(deviceURLSetting, function () {
+            deviceURL = deviceURLSetting.value;
+            db.save(DEVICE_URLSetting, deviceURL);
         });
+
+        utils.bindAutoSaveEvent(rippleURL, function () {
+            rippleURL = rippleURLSetting.value;
+            db.save(RIPPLE_URL, rippleURL);
+        });
+
+        connect();
     },
 
     exec: function (success, fail, service, action, args) {
@@ -63,7 +106,7 @@ module.exports = {
         });
     },
 
-    isAwesome: function () {
+    hasConnectedDevice: function () {
         return ready;
     }
 };

--- a/lib/client/ui/plugins/deviceProxy.js
+++ b/lib/client/ui/plugins/deviceProxy.js
@@ -60,25 +60,22 @@ function connect() {
             socket.on("device-disconnected", function () {
                 show("device-proxy-device-not-connected");
             });
+            socket.on('proxyResp', function (resp) {
+                var callback = callbacks[resp.id];
+                var as = utils.map(resp.args, function(v) { return v; });
+
+                if (resp.win) {
+                    callback.success.apply(null, as);
+                }
+                else {
+                    callback.fail.apply(null, as);
+                }
+            });
         });
         socket.on("disconnect", function () {
             show("device-proxy-error");
         });
 
-        socket.on('proxyResp', function (resp) {
-            var callback = callbacks[resp.id];
-            var as = utils.map(resp.args, function(v) { return v; });
-
-            console.log(as);
-            if (resp.win) {
-                callback.success.apply(null, as);
-            }
-            else {
-                callback.fail.apply(null, as);
-            }
-
-            delete callbacks[resp.id];
-        });
     };
 
     document.body.appendChild(script);

--- a/lib/client/ui/plugins/deviceProxy.js
+++ b/lib/client/ui/plugins/deviceProxy.js
@@ -19,8 +19,7 @@ var RIPPLE_URL = "device-proxy-ripple-url",
     ready = false,
     utils = ripple('utils'),
     db = ripple('db'),
-    rippleURL = db.retrieve(RIPPLE_URL) || "http://localhost:4400",
-    deviceURL = db.retrieve(DEVICE_URL) || "http://localhost:4400",
+    serviceURL = db.retrieve(RIPPLE_URL) || "http://localhost:4400",
     socket;
 
 function el(id) {
@@ -29,12 +28,13 @@ function el(id) {
 
 function show(id) {
     utils.forEach(el(id).parentNode.children, function (element) {
-        console.log(element);
         if (element.id === id) {
-            element.style = "block";
+            element.style.display = "block";
         }
         else {
-            element.style.display = "none";
+            if (element.nodeType === 1) {
+                element.style.display = "none";
+            }
         }
     });
 }
@@ -42,12 +42,12 @@ function show(id) {
 function connect() {
     var script = document.createElement("script");
 
-    script.setAttribute("src", rippleURL + "/socket.io/socket.io.js");
+    script.setAttribute("src", serviceURL + "/socket.io/socket.io.js");
     script.onerror = function () {
         show("device-proxy-error");
     };
     script.onload = function () {
-        socket = io.connect(rippleURL);
+        socket = io.connect(serviceURL);
         socket.on("connect", function () {
             show("device-proxy-device-not-connected");
             socket.emit("set-role", "ripple");
@@ -78,14 +78,12 @@ module.exports = {
         var deviceURLSetting = el(DEVICE_URL),
             rippleURLSetting = el(RIPPLE_URL);
 
-        utils.bindAutoSaveEvent(deviceURLSetting, function () {
-            deviceURL = deviceURLSetting.value;
-            db.save(DEVICE_URLSetting, deviceURL);
-        });
+        deviceURLSetting.innerHTML = serviceURL;
+        rippleURLSetting.value = serviceURL;
 
-        utils.bindAutoSaveEvent(rippleURL, function () {
-            rippleURL = rippleURLSetting.value;
-            db.save(RIPPLE_URL, rippleURL);
+        utils.bindAutoSaveEvent(serviceURL, function () {
+            serviceURL = rippleURLSetting.value;
+            db.save(RIPPLE_URL, serviceURL);
         });
 
         connect();

--- a/lib/client/ui/plugins/deviceProxy.js
+++ b/lib/client/ui/plugins/deviceProxy.js
@@ -17,6 +17,7 @@
 var RIPPLE_URL = "device-proxy-ripple-url",
     DEVICE_URL = "device-proxy-device-url",
     ready = false,
+    callbacks = {},
     utils = ripple('utils'),
     db = ripple('db'),
     serviceURL = db.retrieve(RIPPLE_URL) || "http://localhost:4400",
@@ -63,6 +64,21 @@ function connect() {
         socket.on("disconnect", function () {
             show("device-proxy-error");
         });
+
+        socket.on('proxyResp', function (resp) {
+            var callback = callbacks[resp.id];
+            var as = utils.map(resp.args, function(v) { return v; });
+
+            console.log(as);
+            if (resp.win) {
+                callback.success.apply(null, as);
+            }
+            else {
+                callback.fail.apply(null, as);
+            }
+
+            delete callbacks[resp.id];
+        });
     };
 
     document.body.appendChild(script);
@@ -90,19 +106,18 @@ module.exports = {
     },
 
     exec: function (success, fail, service, action, args) {
+        var id = Math.uuid();
+
+        callbacks[id] = {
+            success: success,
+            fail: fail
+        };
+
         socket.emit('proxyReq', {
             service: service,
             action: action,
+            id: id,
             args: args
-        }, function (result) {
-            var as = utils.map(result.args, function(v) { return v; });
-            console.log(as);
-            if (result.win) {
-                success.apply(null, as);
-            }
-            else {
-                fail.apply(null, as);
-            }
         });
     },
 

--- a/lib/client/ui/plugins/deviceProxy.js
+++ b/lib/client/ui/plugins/deviceProxy.js
@@ -95,11 +95,13 @@ module.exports = {
             action: action,
             args: args
         }, function (result) {
+            var as = utils.map(result.args, function(v) { return v; });
+            console.log(as);
             if (result.win) {
-                success.apply(null, result.args);
+                success.apply(null, as);
             }
             else {
-                fail.apply(null, result.args);
+                fail.apply(null, as);
             }
         });
     },

--- a/lib/client/ui/plugins/deviceProxy.js
+++ b/lib/client/ui/plugins/deviceProxy.js
@@ -59,11 +59,14 @@ function connect() {
                 el("device-proxy-connected-device").innerHTML = device;
             });
             socket.on("device-disconnected", function () {
+                ready = false;
                 show("device-proxy-device-not-connected");
             });
             socket.on('proxyResp', function (resp) {
-                var callback = callbacks[resp.id];
-                var as = utils.map(resp.args, function(v) { return v; });
+                var callback = callbacks[resp.id],
+                    as = utils.map(resp.args, function (v) {
+                        return v;
+                    });
 
                 if (resp.win) {
                     callback.success.apply(null, as);
@@ -101,7 +104,7 @@ module.exports = {
             db.save(RIPPLE_URL, serviceURL);
         });
 
-        event.on('DocumentLoad', function() {
+        event.on('DocumentLoad', function () {
             console.log('document has changed, deviceproxy knows this');
             if (socket && ready) {
                 socket.emit('documentload');

--- a/lib/client/ui/plugins/deviceProxy.js
+++ b/lib/client/ui/plugins/deviceProxy.js
@@ -47,7 +47,7 @@ function connect() {
         show("device-proxy-error");
     };
     script.onload = function () {
-        socket = io.connect(serviceURL);
+        socket = window.io.connect(serviceURL);
         socket.on("connect", function () {
             show("device-proxy-device-not-connected");
             socket.emit("set-role", "ripple");
@@ -56,7 +56,7 @@ function connect() {
                 show("device-proxy-device-connected");
                 el("device-proxy-connected-device").innerHTML = device;
             });
-            socket.on("device-disconnected", function (data) {
+            socket.on("device-disconnected", function () {
                 show("device-proxy-device-not-connected");
             });
         });

--- a/lib/client/ui/plugins/deviceProxy.js
+++ b/lib/client/ui/plugins/deviceProxy.js
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2012 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var ready = false,
+    socket;
+
+module.exports = {
+    panel: {
+        domId: "device-proxy-container",
+        collapsed: true,
+        pane: "left"
+    },
+
+    initialize: function () {
+        var script = document.createElement("script");
+
+        script.setAttribute("src", location.origin + "/socket.io/socket.io.js");
+        script.onerror = function () {
+            fail();
+        };
+        script.onload = function () {
+            socket = io.connect(location.origin);
+            socket.on("connect", function () {
+                socket.emit("set-role", "ripple");
+                socket.on("ready", function (device) {
+                    ready = true;
+                    document.getElementById("device-proxy-connected").innerHtml = device;
+                });
+            });
+        };
+        
+
+        document.body.appendChild(script);
+        
+        document.getElementById("device-proxy-connect").addEventListener("click", function () {
+            //do stuff
+        });
+    },
+
+    exec: function (success, fail, service, action, args) {
+        socket.emit('proxyReq', {
+            service: service,
+            action: action,
+            args: args
+        }, function (result) {
+            if (result.win) {
+                success.apply(null, result.args);
+            }
+            else {
+                fail.apply(null, result.args);
+            }
+        });
+    },
+    
+    isAwesome: function () {
+        return ready;
+    }
+};

--- a/lib/client/ui/plugins/deviceProxy/panel.html
+++ b/lib/client/ui/plugins/deviceProxy/panel.html
@@ -1,0 +1,34 @@
+<!--
+ *  Copyright 2011 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<section id="device-proxy-container" class="ui-box ui-state-default ui-corner-all">
+    <section class="h2 info-header">
+        <section class="collapse-handle">Device Proxy</section>
+        <section class="drag-handle ui-state-default ui-corner-all ui-state-hover">
+            <span class="ui-icon ui-icon-arrow-4"></span>
+        </section>
+    </section>
+
+    <section class="info ui-widget-content ui-corner-all" style="display: none;">
+        <h2>Connected Device</h2> 
+
+        <div id="device-proxy-connected">connected device info goes here</div>
+
+        <button id="device-proxy-connect" class="ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only">
+            <span class="ui-button-text">Connect a Device</span>
+        </button>
+    </section>
+</section>
+

--- a/lib/client/ui/plugins/deviceProxy/panel.html
+++ b/lib/client/ui/plugins/deviceProxy/panel.html
@@ -41,7 +41,6 @@
                 install the <a href="https://github.com/gtanner/ripple-companion" target="_blank">Ripple companion app</a> 
                 and scan the QR code below or enter the URL listed.
             </p>
-            <img id="device-proxy-qr-code" alt="qr code"/>
             <p id="device-proxy-device-url"></p>
         </section>
 

--- a/lib/client/ui/plugins/deviceProxy/panel.html
+++ b/lib/client/ui/plugins/deviceProxy/panel.html
@@ -22,13 +22,33 @@
     </section>
 
     <section class="info ui-widget-content ui-corner-all" style="display: none;">
-        <h2>Connected Device</h2> 
+        <section id="device-proxy-error" style="display:block;">
+            <p class="ui-text-fail">
+                Cannot connect to Ripple socket services. Please start
+                the device proxy services by intalling the Ripple CLI and 
+                running "ripple emulate".
+            </p>
+            <label class="ui-text-label">Services URL:</label>
+            <input id="device-proxy-ripple-url" class="ui-state-default ui-corner-all" />
+            <button id="device-proxy-connect" class="ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only">
+                <span class="ui-button-text">Connect</span>
+            </button>
+        </section>
 
-        <div id="device-proxy-connected">connected device info goes here</div>
+        <section id="device-proxy-device-not-connected" style="display: none;">
+            <p>
+                Ripple is connected to socket services. To connect a device,
+                install the <a href="https://github.com/gtanner/ripple-companion" target="_blank">Ripple companion app</a> 
+                and scan the QR code below or enter the URL listed.
+            </p>
+            <img id="device-proxy-qr-code" alt="qr code"/>
+            <p id="device-proxy-device-url"></p>
+        </section>
 
-        <button id="device-proxy-connect" class="ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only">
-            <span class="ui-button-text">Connect a Device</span>
-        </button>
+        <section id="device-proxy-device-connected" style="display: none;">
+            <h2>Connected Device:</h2> 
+            <div id="device-proxy-connected-device"></div>
+        </section>
     </section>
 </section>
 

--- a/lib/server/deviceProxy.js
+++ b/lib/server/deviceProxy.js
@@ -36,35 +36,32 @@ module.exports = {
         io = connection.io;
 
         io.sockets.on('connection', function (socket) {
-            console.log('got a connection');
             socket.on('set-role', function(role) {
-                console.log('setting a role');
-                if (ripple === undefined && role == 'ripple') {
-                    console.log('ripple');
+                if (role == 'ripple') {
+                    console.log('Ripple for Proxy Connected');
                     ripple = socket;
+                    ripple.on('disconnect', function() {
+                        console.log('Ripple for Proxy Disconnected');
+                    });
                 }
                 if (device === undefined && role.role === 'device') {
                     device = socket;
                     device_name = role.name;
-                    console.log('device: ' + device_name);
+                    console.log('Device for Proxy Connected: ' + device_name);
                     device.on('disconnect', function() {
-                        console.log('device disconnected');
+                        console.log('Device for Proxy Disconnected');
                         if (ripple) ripple.emit('device-disconnected');
                     });
                 }
                 if (ripple && device) {
-                    console.log('both device and ripple are ready');
                     ripple.emit('ready', device_name);
                     ripple.on('proxyReq', function (data) {
-                        console.log('got a proxyReq, emitting exec');
                         device.emit("exec", {
                            service: data.service,
                            action: data.action,
                            args: data.args
                         }, function(result) {
-                            console.log('got a result from device');
-                            console.log(result);
-                            ripple_callback(result);
+                            //console.log('got a result from device');
                             ripple.emit('proxyResp', {
                                 id: data.id,
                                 win: result.win,

--- a/lib/server/deviceProxy.js
+++ b/lib/server/deviceProxy.js
@@ -63,10 +63,10 @@ module.exports = {
                     ripple.emit('ready', device_name);
                     ripple.on('proxyReq', function (data) {
                         device.emit("exec", {
-                           service: data.service,
-                           action: data.action,
-                           args: data.args
-                        }, function(result) {
+                            service: data.service,
+                            action: data.action,
+                            args: data.args
+                        }, function (result) {
                             ripple.emit('proxyResp', {
                                 id: data.id,
                                 win: result.win,

--- a/lib/server/deviceProxy.js
+++ b/lib/server/deviceProxy.js
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2012 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var server = require('./index'),
+    conf = require('./conf'),
+    colors = require('colors');
+
+colors.mode = "console";
+
+module.exports = {
+    start: function (options, connection) {
+        var io,
+            app,
+            ripple,
+            device;
+
+        if (!options) { options = {}; }
+        if (!options.port) { options.port = conf.ports.proxy; }
+        if (!connection) { connection = server.start(options); }
+
+        app = connection.app;
+        io = connection.io;
+
+        io.of(options.route + '/device_proxy/ripple')
+            .on('connection', function (socket) {
+                ripple = socket;
+
+                io.of(options.route + '/device_proxy/device')
+                    .on('connection', function (socket) {
+                        device = socket;
+                    });
+
+                socket.on("proxyReq", function (data) {
+                    device.emit("exec", {
+                               service: "",
+                               action: "",
+                               args: ""
+                    });
+                });
+            });
+
+        console.log("INFO:".green + " device proxy service running on: " +
+            ("http://localhost:" + connection.port + options.route + "/device_proxy").cyan);
+    }
+};

--- a/lib/server/deviceProxy.js
+++ b/lib/server/deviceProxy.js
@@ -37,7 +37,9 @@ module.exports = {
 
         io.sockets.on('connection', function (socket) {
             socket.on('set-role', function(role) {
-                if (ripple === undefined && role == 'ripple') ripple = socket;
+                if (ripple === undefined && role == 'ripple') {
+                    ripple = socket;
+                }
                 if (device === undefined && role.role == 'device') {
                     device = socket;
                     device_name = role.name;

--- a/lib/server/deviceProxy.js
+++ b/lib/server/deviceProxy.js
@@ -36,11 +36,11 @@ module.exports = {
         io = connection.io;
 
         io.sockets.on('connection', function (socket) {
-            socket.on('set-role', function(role) {
-                if (ripple === undefined && role == 'ripple') {
+            socket.on('set-role', function (role) {
+                if (ripple === undefined && role === 'ripple') {
                     ripple = socket;
                 }
-                if (device === undefined && role.role == 'device') {
+                if (device === undefined && role.role === 'device') {
                     device = socket;
                     device_name = role.name;
                 }
@@ -48,16 +48,19 @@ module.exports = {
                     ripple.emit('ready', device_name);
                     ripple.on('proxyReq', function (data, ripple_callback) {
                         device.emit("exec", {
-                           service: data.service,
-                           action: data.action,
-                           args: data.args
+                            service: data.service,
+                            action: data.action,
+                            args: data.args
                         }, ripple_callback);
                     });
                 }
             });
         });
 
-        console.log("INFO:".green + " device proxy service running on: " +
-            ("http://localhost:" + connection.port + options.route + "/device_proxy").cyan);
+        console.log("INFO:".green + " Ripple socket services running on: " +
+            ("http://localhost:" + connection.port).cyan);
+
+        console.log("INFO:".green + " to connect the Ripple Companion app use this URL: " +
+            ("http://localhost:" + connection.port).cyan);
     }
 };

--- a/lib/server/deviceProxy.js
+++ b/lib/server/deviceProxy.js
@@ -55,9 +55,8 @@ module.exports = {
                 if (ripple && device) {
                     console.log('both device and ripple are ready');
                     ripple.emit('ready', device_name);
-                    ripple.on('proxyReq', function (data, ripple_callback) {
+                    ripple.on('proxyReq', function (data) {
                         console.log('got a proxyReq, emitting exec');
-                        console.log(data, ripple_callback);
                         device.emit("exec", {
                            service: data.service,
                            action: data.action,
@@ -66,6 +65,11 @@ module.exports = {
                             console.log('got a result from device');
                             console.log(result);
                             ripple_callback(result);
+                            ripple.emit('proxyResp', {
+                                id: data.id,
+                                win: result.win,
+                                args: result.args
+                            });
                         });
                     });
                 }

--- a/lib/server/deviceProxy.js
+++ b/lib/server/deviceProxy.js
@@ -43,6 +43,12 @@ module.exports = {
                     ripple.on('disconnect', function() {
                         console.log('Ripple for Proxy Disconnected');
                     });
+                    ripple.on('documentload', function() {
+                        console.log('got a documentload event');
+                        if (device) {
+                            device.emit('documentload');
+                        }
+                    });
                 }
                 if (device === undefined && role.role === 'device') {
                     device = socket;
@@ -61,7 +67,6 @@ module.exports = {
                            action: data.action,
                            args: data.args
                         }, function(result) {
-                            //console.log('got a result from device');
                             ripple.emit('proxyResp', {
                                 id: data.id,
                                 win: result.win,

--- a/lib/server/deviceProxy.js
+++ b/lib/server/deviceProxy.js
@@ -36,22 +36,37 @@ module.exports = {
         io = connection.io;
 
         io.sockets.on('connection', function (socket) {
-            socket.on('set-role', function (role) {
-                if (ripple === undefined && role === 'ripple') {
+            console.log('got a connection');
+            socket.on('set-role', function(role) {
+                console.log('setting a role');
+                if (ripple === undefined && role == 'ripple') {
+                    console.log('ripple');
                     ripple = socket;
                 }
                 if (device === undefined && role.role === 'device') {
                     device = socket;
                     device_name = role.name;
+                    console.log('device: ' + device_name);
+                    device.on('disconnect', function() {
+                        console.log('device disconnected');
+                        if (ripple) ripple.emit('device-disconnected');
+                    });
                 }
                 if (ripple && device) {
+                    console.log('both device and ripple are ready');
                     ripple.emit('ready', device_name);
                     ripple.on('proxyReq', function (data, ripple_callback) {
+                        console.log('got a proxyReq, emitting exec');
+                        console.log(data, ripple_callback);
                         device.emit("exec", {
-                            service: data.service,
-                            action: data.action,
-                            args: data.args
-                        }, ripple_callback);
+                           service: data.service,
+                           action: data.action,
+                           args: data.args
+                        }, function(result) {
+                            console.log('got a result from device');
+                            console.log(result);
+                            ripple_callback(result);
+                        });
                     });
                 }
             });

--- a/lib/server/deviceProxy.js
+++ b/lib/server/deviceProxy.js
@@ -36,14 +36,14 @@ module.exports = {
         io = connection.io;
 
         io.sockets.on('connection', function (socket) {
-            socket.on('set-role', function(role) {
-                if (role == 'ripple') {
+            socket.on('set-role', function (role) {
+                if (role === 'ripple') {
                     console.log('Ripple for Proxy Connected');
                     ripple = socket;
-                    ripple.on('disconnect', function() {
+                    ripple.on('disconnect', function () {
                         console.log('Ripple for Proxy Disconnected');
                     });
-                    ripple.on('documentload', function() {
+                    ripple.on('documentload', function () {
                         console.log('got a documentload event');
                         if (device) {
                             device.emit('documentload');
@@ -54,7 +54,7 @@ module.exports = {
                     device = socket;
                     device_name = role.name;
                     console.log('Device for Proxy Connected: ' + device_name);
-                    device.on('disconnect', function() {
+                    device.on('disconnect', function () {
                         console.log('Device for Proxy Disconnected');
                         if (ripple) ripple.emit('device-disconnected');
                     });

--- a/lib/server/deviceProxy.js
+++ b/lib/server/deviceProxy.js
@@ -25,7 +25,8 @@ module.exports = {
         var io,
             app,
             ripple,
-            device;
+            device,
+            device_name;
 
         if (!options) { options = {}; }
         if (!options.port) { options.port = conf.ports.proxy; }
@@ -34,23 +35,25 @@ module.exports = {
         app = connection.app;
         io = connection.io;
 
-        io.of(options.route + '/device_proxy/ripple')
-            .on('connection', function (socket) {
-                ripple = socket;
-
-                io.of(options.route + '/device_proxy/device')
-                    .on('connection', function (socket) {
-                        device = socket;
+        io.sockets.on('connection', function (socket) {
+            socket.on('set-role', function(role) {
+                if (ripple === undefined && role == 'ripple') ripple = socket;
+                if (device === undefined && role.role == 'device') {
+                    device = socket;
+                    device_name = role.name;
+                }
+                if (ripple && device) {
+                    ripple.emit('ready', device_name);
+                    ripple.on('proxyReq', function (data, ripple_callback) {
+                        device.emit("exec", {
+                           service: data.service,
+                           action: data.action,
+                           args: data.args
+                        }, ripple_callback);
                     });
-
-                socket.on("proxyReq", function (data) {
-                    device.emit("exec", {
-                               service: "",
-                               action: "",
-                               args: ""
-                    });
-                });
+                }
             });
+        });
 
         console.log("INFO:".green + " device proxy service running on: " +
             ("http://localhost:" + connection.port + options.route + "/device_proxy").cyan);

--- a/lib/server/emulate.js
+++ b/lib/server/emulate.js
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var proxy = require('./proxy'),
+var xhrProxy = require('./xhrProxy'),
+    deviceProxy = require('./deviceProxy'),
     server = require('./index'),
     colors = require('colors'),
     express = require('express');
@@ -22,7 +23,8 @@ colors.mode = "console";
 
 module.exports = {
     start: function (options) {
-        var app = server.start(options);
+        var connection = server.start(options),
+            app = connection.app;
 
         if (!options.path) { options.path = process.cwd(); }
 
@@ -32,7 +34,8 @@ module.exports = {
             options.route = "/" + options.route;
         }
 
-        app = proxy.start({route: options.route}, app);
+        xhrProxy.start({route: options.route}, connection);
+        deviceProxy.start({route: options.route}, connection);
 
         app.use(express.static(options.path));
 
@@ -40,9 +43,9 @@ module.exports = {
 
         console.log();
         console.log("INFO:".green + " Load the URL below (in Chrome) to auto-enable Ripple.");
-        console.log("      " + ("http://localhost:" + app._port + options.route + "/enable/").cyan);
+        console.log("      " + ("http://localhost:" + connection.port + options.route + "/enable/").cyan);
         console.log();
 
-        return app;
+        return connection;
     }
 };

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -27,7 +27,9 @@ module.exports = {
             port = options.port || conf.ports.main;
 
         server = require('http').createServer(app);
-        io = require('socket.io').listen(server); 
+        io = require('socket.io').listen(server, {
+            'log level': 0 // log errors
+        });
         server.listen(port);
 
         console.log("INFO:".green + " Server instance running on: " + ("http://localhost:" + port).cyan);

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -22,14 +22,21 @@ colors.mode = "console";
 module.exports = {
     start: function (options) {
         var app = express(),
+            server,
+            io,
             port = options.port || conf.ports.main;
 
-        app._port = port;
-        app.listen(port);
+        server = require('http').createServer(app);
+        io = require('socket.io').listen(server); 
+        server.listen(port);
 
         console.log("INFO:".green + " Server instance running on: " + ("http://localhost:" + port).cyan);
 
-        return app;
+        return {
+            app: app,
+            io: io,
+            port: port
+        };
     }
 };
 

--- a/lib/server/xhrProxy.js
+++ b/lib/server/xhrProxy.js
@@ -135,10 +135,10 @@ function jsonpXHRProxyHandler(req, res/*, next*/) {
 
 function start(options, connection) {
     var corsOptions = {
-        origins: ["*"],
-        methods: ['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'CONNECT'],
-        credentials: true,
-        headers: []
+            origins: ["*"],
+            methods: ['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'CONNECT'],
+            credentials: true,
+            headers: []
         },
         app;
 

--- a/lib/server/xhrProxy.js
+++ b/lib/server/xhrProxy.js
@@ -133,17 +133,20 @@ function jsonpXHRProxyHandler(req, res/*, next*/) {
     });
 }
 
-function start(options, app) {
+function start(options, connection) {
     var corsOptions = {
         origins: ["*"],
         methods: ['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'CONNECT'],
         credentials: true,
         headers: []
-    };
+        },
+        app;
 
     if (!options) { options = {}; }
     if (!options.port) { options.port = conf.ports.proxy; }
-    if (!app) { app = server.start(options); }
+    if (!connection) { connection = server.start(options); }
+
+    app = connection.app;
 
     if (!options.route) {
         options.route = "";
@@ -177,11 +180,9 @@ function start(options, app) {
     app.all(options.route + "/jsonp_xhr_proxy", jsonpXHRProxyHandler);
 
     console.log("INFO:".green + " CORS XHR proxy service on: " +
-                ("http://localhost:" + app._port + options.route + "/xhr_proxy").cyan);
+                ("http://localhost:" + connection.port + options.route + "/xhr_proxy").cyan);
     console.log("INFO:".green + " JSONP XHR proxy service on: " +
-                ("http://localhost:" + app._port + options.route + "/jsonp_xhr_proxy").cyan);
-
-    return app;
+                ("http://localhost:" + connection.port + options.route + "/jsonp_xhr_proxy").cyan);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "express": "3.0.0rc5",
     "connect-xcors": "0.5.2",
+    "socket.io": "1.x.x",
     "request": "2.11.4",
     "colors" : "0.6.0-1"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "express": "3.0.0rc5",
     "connect-xcors": "0.5.2",
-    "socket.io": "1.x.x",
+    "socket.io": "0.x.x",
     "request": "2.11.4",
     "colors" : "0.6.0-1"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "main": "./lib/index",
   "dependencies": {
     "express": "3.0.0rc5",
+    "qrcode-npm": "x.x.x",
     "connect-xcors": "0.5.2",
     "socket.io": "0.x.x",
     "request": "2.11.4",

--- a/test/unit/cli/index.js
+++ b/test/unit/cli/index.js
@@ -16,7 +16,7 @@
 describe("cli", function () {
     var cli = require('./../../../lib/cli'),
         parser = require('./../../../lib/cli/parser'),
-        proxy = require('./../../../lib/cli/proxy'),
+        proxy = require('./../../../lib/cli/xhr-proxy'),
         help = require('./../../../lib/cli/help'),
         basicArgs = ["node", "ripple"];
 
@@ -30,26 +30,26 @@ describe("cli", function () {
         });
 
         it("requires cli/command_name and uses the `call` method if no subcommand is given", function () {
-            spyOn(parser, "parse").andReturn({commands: ["proxy"], options: {}});
-            cli.interpret(basicArgs.concat(["proxy"]));
+            spyOn(parser, "parse").andReturn({commands: ["xhr-proxy"], options: {}});
+            cli.interpret(basicArgs.concat(["xhr-proxy"]));
             expect(proxy.call).toHaveBeenCalled();
         });
 
         it("requires cli/command_name and uses the method named after the sub command, if given", function () {
             spyOn(parser, "parse").andReturn({
-                commands: ["proxy", "start"],
+                commands: ["xhr-proxy", "start"],
                 options: {"a": true}
             });
-            cli.interpret(basicArgs.concat(["proxy", "start"]));
+            cli.interpret(basicArgs.concat(["xhr-proxy", "start"]));
             expect(proxy.start).toHaveBeenCalledWith({"a": true});
         });
 
         it("passes any given cli options to the command module", function () {
             spyOn(parser, "parse").andReturn({
-                commands: ["proxy"],
+                commands: ["xhr-proxy"],
                 options: {"a": true}
             });
-            cli.interpret(basicArgs.concat(["proxy", "--a"]));
+            cli.interpret(basicArgs.concat(["xhr-proxy", "--a"]));
             expect(proxy.call).toHaveBeenCalledWith({"a": true});
         });
     });


### PR DESCRIPTION
This feature allows a device running the Ripple Companion app to connect to Ripple UI in such away that Ripple will then pass all API calls to the device rather then emulating their behaviour.

Companion app can be found here: https://github.com/gtanner/ripple-companion

@brentlintner Can you please review this?
