### PR TITLE
Don't re-use cookies across XHR proxy requests.

### DIFF
--- a/lib/server/proxy.js
+++ b/lib/server/proxy.js
@@ -73,7 +73,8 @@ function proxy(req, res, callback) {
         proxyReqData = {
             url: parsedURL,
             method: req.method,
-            headers: proxyReqHeaders
+            headers: proxyReqHeaders,
+            jar: false
         };
 
         if (Object.keys(req.body).length > 0) {


### PR DESCRIPTION
When proxing an XMLHttpRequest call via the XHR proxy, the `jar` option
in the `request` package was turned on by default. This would remember
cookies for future requests, which is bad because each request should be
separate, and the domain for cookies is the proxy's address, which is
invalid, anyways.

As a result, there ended up being a large accruing of
random cookies that had buggy effects, such as hitting
cookie header size limits on various web servers.

This fixed GitHub Issue:

```
http://github.com/blackberry/Ripple-UI/issues/732
```

Side Note:

It seems cookie support, in general, is not feasible with the proxy
enabled, because the remote domain is always the proxy's address, and
not the actual remote domain being requested. This is something to
figure out separately.
